### PR TITLE
meta: rename tdx-signed to tdx-signed-bsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ This layer only works on Embedded Linux 6.3.0 and newer releases.
 
 # Secure boot
 
-To enable secure boot, the `tdx-signed` class needs to be inherited in a configuration file.
+To enable secure boot, the `tdx-signed-bsp` class needs to be inherited in a configuration file.
 
 ```
-INHERIT += "tdx-signed"
+INHERIT += "tdx-signed-bsp"
 ```
 
 When secure boot is enabled:
@@ -46,7 +46,7 @@ When secure boot is enabled:
 
 ## Configuring HAB/AHAB support
 
-When the `tdx-signed` class is inherited, signing bootloader images via HAB/AHAB is enabled by default. Set `TDX_IMX_HAB_ENABLE` to `0` to disable it.
+When the `tdx-signed-bsp` class is inherited, signing bootloader images via HAB/AHAB is enabled by default. Set `TDX_IMX_HAB_ENABLE` to `0` to disable it.
 
 Before using this feature, it is required to:
 
@@ -145,7 +145,7 @@ The command categories are currently only available as part of a [patch](./recip
 
 ## Configuring FIT image signing
 
-When the `tdx-signed` class is inherited, generating and signing a FIT image is enabled by default. Set `UBOOT_SIGN_ENABLE` to `0` to disable it.
+When the `tdx-signed-bsp` class is inherited, generating and signing a FIT image is enabled by default. Set `UBOOT_SIGN_ENABLE` to `0` to disable it.
 
 This features uses the default FIT image signing support provided by the `uboot-sign` and `kernel-fitimage` classes from OpenEmbedded Core. See the [Yocto Project documentation](https://docs.yoctoproject.org/ref-manual/classes.html#kernel-fitimage) for more details.
 

--- a/classes/tdx-signed-bsp.bbclass
+++ b/classes/tdx-signed-bsp.bbclass
@@ -1,5 +1,5 @@
 # globally enable signed images
-DISTROOVERRIDES:append = ":tdx-signed"
+DISTROOVERRIDES:append = ":tdx-signed-bsp"
 
 # FIT image configuration
 require tdx-signed-fit-image.inc

--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -23,7 +23,7 @@ TDX_UBOOT_HARDENING_ENABLE ?= "${@'1' if bb.utils.to_boolean(d.getVar('TDX_IMX_H
 # this will be changed in the future.
 #
 # TODO: Set TDX_SECBOOT_REQUIRED_BOOTARGS differently based on overrides
-# "tdx-signed" or "torizon-signed"; the former for booting the BSP reference
+# "tdx-signed-bsp" or "tdx-signed-torizon"; the former for booting the BSP reference
 # image and the latter for Torizon OS.
 #
 # TODO: Use variable OSTREE_KERNEL_ARGS provided by layer meta-toradex-torizon

--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -1,1 +1,1 @@
-require ${@ 'u-boot-distro-boot-harden.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'u-boot-distro-boot-harden.inc' if 'tdx-signed-bsp' in d.getVar('OVERRIDES').split(':') else ''}

--- a/recipes-bsp/u-boot/u-boot-toradex-ti_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-toradex-ti_%.bbappend
@@ -1,1 +1,1 @@
-require ${@ 'u-boot-secure-boot.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'u-boot-secure-boot.inc' if 'tdx-signed-bsp' in d.getVar('OVERRIDES').split(':') else ''}

--- a/recipes-bsp/u-boot/u-boot-toradex_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-toradex_%.bbappend
@@ -1,1 +1,1 @@
-require ${@ 'u-boot-secure-boot.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'u-boot-secure-boot.inc' if 'tdx-signed-bsp' in d.getVar('OVERRIDES').split(':') else ''}

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,1 @@
-require ${@ 'u-boot-secure-boot.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'u-boot-secure-boot.inc' if 'tdx-signed-bsp' in d.getVar('OVERRIDES').split(':') else ''}

--- a/recipes-kernel/linux/device-tree-overlays-mainline_%.bbappend
+++ b/recipes-kernel/linux/device-tree-overlays-mainline_%.bbappend
@@ -1,1 +1,1 @@
-require ${@ 'add-secboot-kargs-overlay.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'add-secboot-kargs-overlay.inc' if 'tdx-signed-bsp' in d.getVar('OVERRIDES').split(':') else ''}

--- a/recipes-kernel/linux/device-tree-overlays_%.bbappend
+++ b/recipes-kernel/linux/device-tree-overlays_%.bbappend
@@ -1,1 +1,1 @@
-require ${@ 'add-secboot-kargs-overlay.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'add-secboot-kargs-overlay.inc' if 'tdx-signed-bsp' in d.getVar('OVERRIDES').split(':') else ''}


### PR DESCRIPTION
To standardize the names for BSP reference images and Torizon OS images, it was decided that BSP signed images would inherit tdx-signed-bsp and Torizon OS signed images would inherit tdx-signed-torizon.

So let's change the name of the class and the override for BSP signed images to tdx-signed-bsp.