### PR TITLE
Add support to sign AM62 boot artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ A few variables can be used to configure this feature, including:
 | `UBOOT_SIGN_ENABLE` | Enable signing of FIT image | `1` |
 | `FIT_GENERATE_KEYS` | Generate signing keys | `1` |
 | `UBOOT_SIGN_KEYDIR` | Location of the RSA key and certificate used for signing | `${TOPDIR}/keys/fit` |
-| `UBOOT_SIGN_KEYNAME` | The name of the key used for signing | `dev` |
+| `UBOOT_SIGN_KEYNAME` | The name of the key used for signing configuration nodes | `dev` |
+| `UBOOT_SIGN_IMG_KEYNAME` | The name of the key used for signing individual images | `dev2` |
 
 The complete list of variables can be found in the `tdx-signed-fit-image.inc` file.
 

--- a/classes/tdx-signed-fit-image.inc
+++ b/classes/tdx-signed-fit-image.inc
@@ -8,6 +8,7 @@ UBOOT_SIGN_ENABLE:verdin-am62-k3r5 = "0"
 UBOOT_MKIMAGE_DTCOPTS = "-I dts -O dtb -p 2000"
 UBOOT_SIGN_KEYDIR ?= "${TOPDIR}/keys/fit"
 UBOOT_SIGN_KEYNAME ?= "dev"
+UBOOT_SIGN_IMG_KEYNAME ?= "dev2"
 
 # parameters to generate the keys to sign the FIT image
 FIT_GENERATE_KEYS ?= "1"

--- a/classes/tdx-signed-k3-hs-se.inc
+++ b/classes/tdx-signed-k3-hs-se.inc
@@ -1,0 +1,14 @@
+# enable K3 HS-SE (High Security - Security Enforced)
+TDX_K3_HSSE_ENABLE ?= "1"
+
+# signing key location
+TDX_K3_HSSE_KEY_DIR ?= "${TOPDIR}/keys/ti"
+
+# build secure variant of tiboot3.bin
+SYSFW_SUFFIX = "hs"
+
+# use tiboot3.bin secure boot variant in Tezi
+FIRMWARE_BINARY[0073] = "tiboot3-am62x-hs-verdin.bin"
+FIRMWARE_BINARY[0074] = "tiboot3-am62x-hs-verdin.bin"
+FIRMWARE_BINARY[0075] = "tiboot3-am62x-hs-verdin.bin"
+FIRMWARE_BINARY[0076] = "tiboot3-am62x-hs-verdin.bin"

--- a/classes/tdx-signed.bbclass
+++ b/classes/tdx-signed.bbclass
@@ -7,5 +7,9 @@ require tdx-signed-fit-image.inc
 # IXM HAB configuration
 require ${@ 'tdx-signed-imx-hab.inc' if 'imx-generic-bsp' in d.getVar('OVERRIDES').split(':') else ''}
 
+# TI K3 HS-SE (High Security - Security Enforced) configuration
+require ${@ 'tdx-signed-k3-hs-se.inc' if 'k3r5' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'tdx-signed-k3-hs-se.inc' if 'k3' in d.getVar('OVERRIDES').split(':') else ''}
+
 # Hardening configuration
 require tdx-signed-harden.inc

--- a/recipes-bsp/u-boot/u-boot-hsse.inc
+++ b/recipes-bsp/u-boot/u-boot-hsse.inc
@@ -1,0 +1,8 @@
+update_signing_keys() {
+    rm -Rf ${S}/board/ti/keys
+    ln -s ${TDX_K3_HSSE_KEY_DIR} ${S}/board/ti/keys
+}
+
+do_unpack:append() {
+    bb.build.exec_func('update_signing_keys', d)    
+}

--- a/recipes-bsp/u-boot/u-boot-secure-boot.inc
+++ b/recipes-bsp/u-boot/u-boot-secure-boot.inc
@@ -6,5 +6,8 @@ require ${@oe.utils.conditional('UBOOT_SIGN_ENABLE', '1', 'u-boot-fit-signature.
 # enable HAB support
 require ${@oe.utils.conditional('TDX_IMX_HAB_ENABLE', '1', 'u-boot-hab.inc', '', d)}
 
+# enable TI K3 HS-SE (High Security - Security Enforced) support
+require ${@oe.utils.conditional('TDX_K3_HSSE_ENABLE', '1', 'u-boot-hsse.inc', '', d)}
+
 # enable U-Boot hardening
 require ${@oe.utils.conditional('TDX_UBOOT_HARDENING_ENABLE', '1', 'u-boot-harden.inc', '', d)}

--- a/recipes-ti/secdev/ti-k3-secdev_%.bbappend
+++ b/recipes-ti/secdev/ti-k3-secdev_%.bbappend
@@ -1,0 +1,8 @@
+update_signing_keys() {
+    rm -Rf ${S}/keys
+    ln -s ${TDX_K3_HSSE_KEY_DIR} ${S}/keys
+}
+
+do_unpack:append() {
+    bb.build.exec_func('update_signing_keys', d)    
+}


### PR DESCRIPTION
Tested by using TI OTP Writer to fuse the keys and change the SoC to HS-SE (High Security - Security Enforced) mode. I could only boot a signed image after it. Logs from the initial boot:

```
U-Boot SPL 2023.04-6.5.0-devel+git.a8177718dd35 (Feb 14 2024 - 08:09:01 +0000)
SYSFW ABI: 3.1 (firmware rev 0x0009 '9.1.8--v09.01.08 (Kool Koala)')
SPL initial stack usage: 13384 bytes
Trying to boot from MMC1                                                                                                                                                  Authentication passed                                                                                                                                                                                              
Authentication passed                                                                                                                                                                                              
Authentication passed                                                                                                                                                                                              
Authentication passed                                                                                                                                                                                              
Authentication passed                                                                                                                                                                                              
Starting ATF on ARM64 core...                                                                                                                                                                                      
                                                                                                                                                                                                                   
NOTICE:  BL31: v2.9(release):v2.9.0-614-gd7a7135d32a8-dirty                                                                                                                                                        
NOTICE:  BL31: Built : 09:34:15, Aug 24 2023                                                                                                                                                                       
                                                                                                                                                                                                                   
U-Boot SPL 2023.04-6.5.0-devel+git.a8177718dd35 (Feb 14 2024 - 08:09:01 +0000)                                                                                                                                     
SYSFW ABI: 3.1 (firmware rev 0x0009 '9.1.8--v09.01.08 (Kool Koala)')                                                                                                                                               
SPL initial stack usage: 1856 bytes                                                                                                                                                                                
Trying to boot from MMC1                                                                                                                                                                                           
Authentication passed                                                                                    
Authentication passed                                                                                                                                                                                              
                                                                                                         
U-Boot 2023.04-6.5.0-devel+git.a8177718dd35 (Feb 14 2024 - 08:09:01 +0000)

SoC:   AM62X SR1.0 HS-SE                                                                                 
DRAM:  1 GiB                                                                                                                                                                                                       
Core:  143 devices, 31 uclasses, devicetree: separate                                                                                                                                                              
MMC:   mmc@fa10000: 0, mmc@fa00000: 1                                                                                                                                                                              
Loading Environment from MMC... OK                                                                                                                                                                                 
In:    serial@2800000                                                                                                                                                                                              
Out:   serial@2800000
Err:   serial@2800000
Model: Toradex 0073 Verdin AM62 Dual 1GB ET V1.1A
```