### PR TITLE
ti-k3-secdev: apply append only if secure boot is enabled

### DIFF
--- a/recipes-ti/secdev/ti-k3-secdev-hsse.inc
+++ b/recipes-ti/secdev/ti-k3-secdev-hsse.inc
@@ -1,0 +1,8 @@
+update_signing_keys() {
+    rm -Rf ${S}/keys
+    ln -s ${TDX_K3_HSSE_KEY_DIR} ${S}/keys
+}
+
+do_unpack:append() {
+    bb.build.exec_func('update_signing_keys', d)
+}

--- a/recipes-ti/secdev/ti-k3-secdev_%.bbappend
+++ b/recipes-ti/secdev/ti-k3-secdev_%.bbappend
@@ -1,8 +1,1 @@
-update_signing_keys() {
-    rm -Rf ${S}/keys
-    ln -s ${TDX_K3_HSSE_KEY_DIR} ${S}/keys
-}
-
-do_unpack:append() {
-    bb.build.exec_func('update_signing_keys', d)    
-}
+require ${@oe.utils.conditional('TDX_K3_HSSE_ENABLE', '1', 'ti-k3-secdev-hsse.inc', '', d)}


### PR DESCRIPTION
The changes to update the signing keys should only be applied if secure boot is enabled.