### PR TITLE
classes: introduce tdxref-signed class

### DIFF
--- a/classes/tdx-signed-dmverity.bbclass
+++ b/classes/tdx-signed-dmverity.bbclass
@@ -1,0 +1,6 @@
+# a ramdisk is required to check the signature of the rootfs image
+INITRAMFS_IMAGE ?= "tdx-reference-ramdisk-image"
+INITRAMFS_IMAGE_BUNDLE ?= "0"
+
+# use the FIT image with the ramdisk
+KERNEL_IMAGE_NAME:prepend = "${INITRAMFS_IMAGE_NAME}-"

--- a/classes/tdxref-signed.bbclass
+++ b/classes/tdxref-signed.bbclass
@@ -1,0 +1,5 @@
+# sign bootloader and kernel artifacts
+inherit tdx-signed
+
+# boot a signed rootfs via dm-verity
+inherit tdx-signed-dmverity

--- a/recipes-images/images/tdx-reference-ramdisk-image.bb
+++ b/recipes-images/images/tdx-reference-ramdisk-image.bb
@@ -1,0 +1,47 @@
+SUMMARY = "Toradex Embedded Linux Reference Ramdisk Image"
+DESCRIPTION = "Minimal ramdisk image to boot a dm-verity based rootfs"
+
+LICENSE = "MIT"
+
+# Some Toradex machines append a value to IMAGE_BASENAME (e.g. -upstream
+# is appended on Colibri iMX6). This currently causes an issue when the
+# ramdisk image is deployed, because IMAGE_BASENAME != INITRAMFS_IMAGE_NAME.
+# So let's use an anonymous function to forcibly set IMAGE_BASENAME
+# and avoid any appends to it
+export IMAGE_BASENAME
+python (){
+    d.setVar('IMAGE_BASENAME', 'tdx-reference-ramdisk-image')
+}
+
+IMAGE_NAME_SUFFIX ?= ""
+IMAGE_LINGUAS = ""
+
+INITRAMFS_SCRIPTS ?= "\
+    initramfs-framework-base \
+    initramfs-module-udev \
+"
+
+PACKAGE_INSTALL = "\
+    ${INITRAMFS_SCRIPTS} \
+    ${VIRTUAL-RUNTIME_base-utils} \
+    udev \
+"
+
+IMAGE_FEATURES = ""
+
+# avoid any circular dependencies
+DEPENDS:remove = "\
+    u-boot-default-script \
+    virtual/bootloader \
+    imx-boot \
+    tezi-metadata \
+    virtual/dtb \
+"
+
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+IMAGE_FSTYPES:remove = "teziimg"
+
+inherit core-image
+
+IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"


### PR DESCRIPTION
This class is responsible for creating a verified BSP reference image with full chain-of-trust support.

It inherits `tdx-signed` to sign boot artifacts (bootloader and FIT image) and `tdx-signed-dmverity` to boot a signed rootfs image with dm-verity.

The `tdx-signed-dmverity.class` implementation is currently incomplete, and for now it just builds and boots the rootfs via a ramdisk image (required for the dm-verity signature verification).

Build tested on Verdin AM62, Verdin iMX8MP and Colibri iMX6.

Runtime tested on Verdin iMX8MP and Colibri iMX6.