### PR TITLE
tdx-signed.bbclass: fix issue when including IMX HAB config file

### DIFF
--- a/classes/tdx-signed.bbclass
+++ b/classes/tdx-signed.bbclass
@@ -5,7 +5,8 @@ DISTROOVERRIDES:append = ":tdx-signed"
 require tdx-signed-fit-image.inc
 
 # IXM HAB configuration
-require ${@ 'tdx-signed-imx-hab.inc' if 'imx-generic-bsp' in d.getVar('OVERRIDES').split(':') else ''}
+MACHINEOVERRIDES_EXTENDER ?= ""
+require ${@ 'tdx-signed-imx-hab.inc' if 'imx-generic-bsp' in d.getVar('MACHINEOVERRIDES_EXTENDER').split(':') else ''}
 
 # TI K3 HS-SE (High Security - Security Enforced) configuration
 require ${@ 'tdx-signed-k3-hs-se.inc' if 'k3r5' in d.getVar('OVERRIDES').split(':') else ''}


### PR DESCRIPTION
'imx-generic-bsp' is not populated in 'OVERRIDES' when parsing this class, so the 'OVERRIDES' variable cannot be used in this context.

The reason for this is that NXP BSP adds several machine overrides to a custom variable called 'MACHINEOVERRIDES_EXTENDER', and this variable is parsed by a class in 'meta-freescale' called
'machine-overrides-extender.bbclass'.

This class registers a function called 'machine_overrides_extender_handler' that will add 'MACHINEOVERRIDES_EXTENDER' to 'MACHINEOVERRIDES', that goes later to 'OVERRIDES'.

But this function is registered to run only AFTER the parsing is done. So that means there are a few overrides from NXP that will only be populated into 'OVERRIDES' in the end of the parsing.

Fix this by using 'MACHINEOVERRIDES_EXTENDER' instead of 'OVERRIDES'.

Fixes #15