### PR TITLE
tdx-signed: enable hardening only on Torizon OS images

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The hardening features above are controlled by the following variables:
 
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
-| `TDX_UBOOT_HARDENING_ENABLE` | Enable hardening features as a whole | `1` if both `TDX_IMX_HAB_ENABLE` and `UBOOT_SIGN_ENABLE` are set or 0 otherwise |
+| `TDX_UBOOT_HARDENING_ENABLE` | Enable hardening features as a whole | `1` if building a Torizon OS image with both `TDX_IMX_HAB_ENABLE` and `UBOOT_SIGN_ENABLE` set; `0` otherwise |
 | `TDX_SECBOOT_REQUIRED_BOOTARGS` | Expected value for the fixed part of the kernel command line | Different value for each machine (suitable for Torizon OS) |
 
 Obs.: Currently, U-Boot hardening is not enabled on Verdin AM62.

--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -9,10 +9,23 @@
 # combination UBOOT_SIGN_ENABLE="0" TDX_UBOOT_HARDENING_ENABLE="1" is not very
 # helpful and can prevent the loading of non-FIT images.
 #
-# Because of the above, we enable the hardening only if both TDX_IMX_HAB_ENABLE
-# and UBOOT_SIGN_ENABLE are set, by default.
+# Moreover, currently the hardening is tested only with Torizon OS and it's
+# not expected to work out of the box with BSP images.
 #
-TDX_UBOOT_HARDENING_ENABLE ?= "${@'1' if bb.utils.to_boolean(d.getVar('TDX_IMX_HAB_ENABLE')) and bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE')) else '0'}"
+# Because of the above, we enable the hardening only when building Torizon OS
+# images provided that both TDX_IMX_HAB_ENABLE and UBOOT_SIGN_ENABLE are set, by
+# default.
+#
+def default_tdx_uboot_hardening_enable(d):
+    # TODO: Remove this condition once support for BSP images is added.
+    if "torizon" not in d.getVar("OVERRIDES").split(":"):
+        return False
+    if (bb.utils.to_boolean(d.getVar('TDX_IMX_HAB_ENABLE')) and
+        bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE'))):
+        return True
+    return False
+
+TDX_UBOOT_HARDENING_ENABLE ?= "${@'1' if default_tdx_uboot_hardening_enable(d) else '0'}"
 
 # Configure one of the hardening features: the "bootargs protection"; with this
 # protection, the fixed part of the kernel command line (boot arguments) are

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -23,7 +23,11 @@ SRC_URI:append:use-mainline-bsp = "\
 "
 
 do_compile:prepend() {
-    if [ "${TDX_IMX_HAB_ENABLE}" = "0" -a "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
+    if [ "${TDX_IMX_HAB_ENABLE}" = "0" ] && [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
         bbfatal 'The combination TDX_IMX_HAB_ENABLE = "0" and TDX_UBOOT_HARDENING_ENABLE = "1" is not allowed: the whitelisting feature (part of the hardening) currently relies on HAB/AHAB.'
+    fi
+    if [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ] && \
+       [ "${@'1' if 'torizon' in d.getVar('OVERRIDES').split(':') else '0'}" != "1" ]; then
+        bbfatal 'U-Boot hardening feature (enabled by TDX_UBOOT_HARDENING_ENABLE=1) is currently tested with Torizon OS only and is not expected to work with BSP images.'
     fi
 }


### PR DESCRIPTION
Since hardening is supported and tested only on Torizon OS, enable it by default only when building such images. At the moment hardening features are not expected to work out of the box with BSP images, so keeping it enabled with them will cause more harm than good (Since hardening is supported and tested only on Torizon OS, enable it by default only when building such OS images. At the moment the hardening features are not expected to work out of the box with BSP images, so keeping it enabled will cause more harm than good (as it was the case on issue #20).
