### PR TITLE
Enable usage of OP-TEE when secure boot is enabled

### DIFF
--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -32,9 +32,6 @@ python validate_optee_support() {
     if machine not in supported_machines:
         bb.fatal("OP-TEE is currently not supported on '%s' machine!" % machine)
 
-    if 'tdx-signed' in d.getVar('OVERRIDES').split(':'):
-        bb.fatal("Currently, OP-TEE cannot be used together with secure boot because the OP-TEE firmware is not being signed!")
-
     if 'tdx-signed-dmverity' in d.getVar('OVERRIDES').split(':'):
         bb.fatal("Currently, OP-TEE cannot be used together with dm-verity because it needs a writable rootfs!")
 }

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -47,9 +47,6 @@ There is also a complete test suite that can be used to validate OP-TEE:
 
 In case of issues, try enabling debug messages via the `TDX_OPTEE_DEBUG` variable.
 
-## Current limitations
+## Limitation
 
-There are two main limitations in the current implementation:
-
-- OP-TEE needs a read-write filesystem (by default, it writes to `/data/tee/`). When rootfs signature check is enabled via the `tdxref-signed` class, the rootfs will be read-only, and OP-TEE will not work because it will not be able to write to the filesystem. This can be worked around by mounting a writable partition to `/data`.
-- The generated OP-TEE firmware is currently not being signed, so secure boot will not work if OP-TEE is enabled.
+There is currently one limitation in the implementation. OP-TEE needs a read-write filesystem (by default, it writes to `/data/tee/`). When rootfs signature check is enabled via the `tdxref-signed` class, the rootfs will be read-only, and OP-TEE will not work because it will not be able to write to the filesystem. This can be worked around by mounting a writable partition to `/data`.


### PR DESCRIPTION
Alright, so I was testing this before in a module with the wrong keys fused!

After fusing the correct keys in a new module, I could confirm secure boot works when OP-TEE is enabled

```
# fuse read 6 0 4
Reading bank 6:
Word 0x00000000: b9bb8a0c 2ff6c619 79b3a9f0 9d426fe6

Verdin iMX8MP # fuse read 7 0 4
Reading bank 7:
Word 0x00000000: 92523418 d01d4e2b a23ccf8c 3d794bac

# hab_status 
Secure boot disabled
HAB Configuration: 0xf0, HAB State: 0x66
No HAB Events Found!
```

And that makes sense. The OP-TEE firmware goes to a FIT image that is being signed by the [generate_csf_fit()](https://github.com/toradex/meta-toradex-security/blob/kirkstone-6.x.y/dynamic-layers/freescale/recipes-bsp/imx-mkimage/files/mx8m_create_csf.sh#L177) function.

So we can safely enable OP-TEE together with secure boot. :-)