### PR TITLE
Introduce class to create data partition

### DIFF
--- a/classes/tdx-tezi-data-partition.bbclass
+++ b/classes/tdx-tezi-data-partition.bbclass
@@ -1,0 +1,33 @@
+# override for conditional assignment
+DISTROOVERRIDES:append = ":tdx-tezi-data-partition"
+
+# data partition filesystem type
+# supported values: ext2, ext3, ext4, fat, ubifs
+# obs.: this is limited to what Easy Installer supports
+TDX_TEZI_DATA_PARTITION_TYPE ?= "ext4"
+
+# data partition label
+TDX_TEZI_DATA_PARTITION_LABEL ?= "DATA"
+
+# automount data partition at boot time
+TDX_TEZI_DATA_PARTITION_AUTOMOUNT ?= "1"
+
+# data partition mount point
+TDX_TEZI_DATA_PARTITION_MOUNTPOINT ?= "/data"
+
+# data partition mount flags
+TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS ?= "rw,nosuid,nodev,noatime,errors=remount-ro"
+
+# image_type_tezi.bbclass configuration
+TEZI_DATA_ENABLED = "1"
+TEZI_DATA_FSTYPE = "${TDX_TEZI_DATA_PARTITION_TYPE}"
+TEZI_DATA_LABEL = "${TDX_TEZI_DATA_PARTITION_LABEL}"
+
+# check if tezi image is enabled
+addhandler validate_tezi_support
+validate_tezi_support[eventmask] = "bb.event.SanityCheck"
+python validate_tezi_support() {
+    enabled_images = e.data.getVar('IMAGE_FSTYPES')
+    if 'teziimg' not in enabled_images:
+        bb.fatal("tdx-tezi-data-partition class only works with Easy Installer images, and teziimg is not enabled!")
+}

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,8 @@
+do_install:append:tdx-tezi-data-partition() {
+    AUTO=$([ "${TDX_TEZI_DATA_PARTITION_AUTOMOUNT}" = "1" ] && echo "auto" || echo "noauto")
+    echo "LABEL=DATA  ${TDX_TEZI_DATA_PARTITION_MOUNTPOINT}  auto  ${TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS},${AUTO}  0  0" >> ${D}/etc/fstab
+}
+
+pkg_postinst:${PN}:append:tdx-tezi-data-partition() {
+    mkdir -p $D${TDX_TEZI_DATA_PARTITION_MOUNTPOINT}
+}


### PR DESCRIPTION
This class will enable the creation of a data partition in the eMMC for Easy Installer images.

This will make it possible to have a read-write partition for situations where the rootfs is read-only (e.g. when dm-verity is enabled).

A few additional variables can be used to configure this feature:

- `TDX_TEZI_DATA_PARTITION_TYPE`: data partition filesystem type (ext2, ext3, ext4, fat, ubifs)
- `TDX_TEZI_DATA_PARTITION_LABEL`: data partition label
- `TDX_TEZI_DATA_PARTITION_AUTOMOUNT`: configure whether the data partition should be automatically mounted at boot time or not
- `TDX_TEZI_DATA_PARTITION_MOUNTPOINT`: data partition mount point
- `TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS`: data partition mount flags (to be added to fstab)

This depends on a feature added to `image_type_tezi.bbclass` in `meta-toradex-bsp-common`, already merged upstream:

https://git.toradex.com/cgit/meta-toradex-bsp-common.git/commit/?h=kirkstone-6.x.y&id=bbb39c255936a130c18d4eb9410b9558fe5a137b

Build and runtime tested on Verdin iMX8MP.