### PR TITLE
Document tdx-tezi-data-partition class and enable OP-TEE when dm-verity is being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For more information on the available features, please check the corresponding d
 | [docs/README-secure-boot-k3.md](docs/README-secure-boot-k3.md) | Details on the secure boot implementation for TI K3 based SoMs (e.g. AM62) |
 | [docs/README-encryption.md](docs/README-encryption.md) | General documentation about the data-at-rest encryption feature |
 | [docs/README-optee.md](docs/README-optee.md) | Documentation on how to run a Trusted Execution Environment (OP-TEE) together with the Linux kernel |
+| [docs/README-data-partition.md](docs/README-data-partition.md) | Documentation on how to create an additional partition for storing persistent data |
 
 This layer only works on Toradex Embedded Linux 6.3.0 and newer releases.
 

--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -23,6 +23,10 @@ IMAGE_INSTALL:append = "\
     ${@oe.utils.conditional('TDX_OPTEE_INSTALL_TESTS', '1', '${TDX_OPTEE_PACKAGES_TESTS}', '', d)} \
 "
 
+# enable data partition if dm-verity and tezi are both enabled
+inherit ${@ 'tdx-tezi-data-partition' if 'teziimg' in d.getVar('IMAGE_FSTYPES') and \
+            'tdx-signed-dmverity' in d.getVar('OVERRIDES').split(':') else ''}
+
 # validate optee support
 addhandler validate_optee_support
 validate_optee_support[eventmask] = "bb.event.SanityCheck"
@@ -31,7 +35,4 @@ python validate_optee_support() {
     machine = e.data.getVar('MACHINE')
     if machine not in supported_machines:
         bb.fatal("OP-TEE is currently not supported on '%s' machine!" % machine)
-
-    if 'tdx-signed-dmverity' in d.getVar('OVERRIDES').split(':'):
-        bb.fatal("Currently, OP-TEE cannot be used together with dm-verity because it needs a writable rootfs!")
 }

--- a/docs/README-data-partition.md
+++ b/docs/README-data-partition.md
@@ -1,0 +1,30 @@
+# Data partition
+
+Sometimes it is useful (or even required) to have an additional partition to store application data and other software artifacts:
+
+- If the `tdxref-signed` class is used to enable secure boot, the rootfs partition will be read-only, and an additional partition might be needed to store persistent data.
+- If the `tdx-encrypted` class is used to enable encryption, an additional partition in the eMMC can be used to store the encrypted data.
+
+For these and other use cases, this layer supports creating an additional data partition in the eMMC via the `tdx-tezi-data-partition` class.
+
+**Important: This class only works with Toradex Easy Installer images.**
+
+## Enabling the data partition
+
+To enable the creation of the data partition in Toradex Easy Installer images, one needs to globally inherit the `tdx-tezi-data-partition` class by adding the following line to an OE configuration file (e.g. your `local.conf`):
+
+```
+INHERIT += "tdx-tezi-data-partition"
+```
+
+Additional variables can be used to customize the behavior of this feature:
+
+| Variable | Description | Default value |
+| :------- | :---------- | :------------ |
+| TDX_TEZI_DATA_PARTITION_TYPE | Data partition filesystem type. Supported values are `ext2`, `ext3`, `ext4`, `fat` and `ubifs`. The supported values are limited to what Toradex Easy Installer supports | `ext4` |
+| TDX_TEZI_DATA_PARTITION_LABEL | Label that will be used to format and mount the data partition | `DATA` |
+| TDX_TEZI_DATA_PARTITION_AUTOMOUNT | Set to `1` to automatically mount the data partition at boot time, or `0` to disable automouting the partition | `1` |
+| TDX_TEZI_DATA_PARTITION_MOUNTPOINT | Directory where the data partition should be mounted | `/data` |
+| TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS | Flags used to mount the data partition. See the `mount` man page for more information on the available mount flags | `rw,nosuid,nodev,noatime, errors=remount-ro` |
+
+Additional variables from the `image_type_tezi` class in the `meta-toradex-bsp-common` layer can be used to customize the creation of the data partition. Please see the [source code of this class](https://git.toradex.com/cgit/meta-toradex-bsp-common.git/tree/classes/image_type_tezi.bbclass?h=kirkstone-6.x.y#n37) for more information.

--- a/docs/README-encryption.md
+++ b/docs/README-encryption.md
@@ -63,3 +63,7 @@ Here is the complete list of variables that can be used to customize the behavio
 | TDX_ENC_STORAGE_MOUNTPOINT | Directory to mount the encrypted partition | `/run/encdata` |
 
 IMPORTANT: The script that mounts the encrypted partition runs early in the boot process, where not necessarily udev has run/settled. For that reason, it is recommended to use the name of the partition as assigned by the kernel (e.g. `/dev/sdb1`). If one wants to set a name that relies on udev rules then one must review the systemd dependencies of the service to ensure the name is available.
+
+## Encrypting a partition in the eMMC
+
+In case you want to create an additional partition in the eMMC to store encrypted data, you can use the `tdx-tezi-data-partition` class. For more information, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -25,6 +25,14 @@ A few variables can be used to customize the behavior of this feature:
 | TDX_OPTEE_DEBUG | Enable OP-TEE debug messages to the serial console (`1` to enable or `0` to disable) | `0` |
 | TDX_OPTEE_INSTALL_TESTS | Enable the installation of OP-TEE test applications (`1` to enable or `0` to disable) | `0` |
 
+## Read-write filesystem for OP-TEE
+
+OP-TEE needs a read-write filesystem (by default, it writes to `/data/tee/`). When rootfs signature checking is enabled via the `tdxref-signed` class, the rootfs image will be generated using the `dm-verity` kernel feature, which is read-only.
+
+In this case, to provide a read-write filesystem to OP-TEE, the `tdx-tezi-data-partition` class will be automatically inherited. This class will create an additional partition in the eMMC and mount it by default at `/data`. For more information on how this class works, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).
+
+In case your rootfs is read-only and you are not using a Toradex Easy Installer image, make sure the `/data` directory is mounted at a read-write partition, or OP-TEE will not work properly.
+
 ## Testing OP-TEE
 
 OP-TEE can be validated using its test applications, which can be installed in the image by adding the following line to an OE configuration file (e.g. `local.conf`):
@@ -46,7 +54,3 @@ There is also a complete test suite that can be used to validate OP-TEE:
 ```
 
 In case of issues, try enabling debug messages via the `TDX_OPTEE_DEBUG` variable.
-
-## Limitation
-
-There is currently one limitation in the implementation. OP-TEE needs a read-write filesystem (by default, it writes to `/data/tee/`). When rootfs signature check is enabled via the `tdxref-signed` class, the rootfs will be read-only, and OP-TEE will not work because it will not be able to write to the filesystem. This can be worked around by mounting a writable partition to `/data`.

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -125,3 +125,11 @@ DM_VERITY_IMAGE = "my-custom-image"
 ```
 
 In case you don't want to boot a signed rootfs image, then instead of inheriting `tdxref-signed`, you should inherit `tdx-signed`. When inheriting `tdx-signed` the bootloader and the FIT image will be signed, but the rootfs image signing process with `dm-verity` will be skipped.
+
+## Additional partition for persistent data
+
+When `tdxref-signed` is used to enable secure boot, the rootfs image is generated using the `dm-verity` kernel feature.
+
+Because `dm-verity` is read-only, you might want to create an additional partition in the eMMC to store persistent data.
+
+If that is the case, you can use the `tdx-tezi-data-partition` class. For more information, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).


### PR DESCRIPTION
This pull request adds some documentation about the data partition feature, and also enables the usage of OP-TEE when dm-verity is enabled.

Commits in this PR:

- 77f8e7c7225b tdx-optee.bbclass: enable usage when dm-verity is enabled
- 0b4d1fe71928 docs/README-encryption.md: document data partition
- 676372675e51 docs/README-secure-boot.md: document data partition
- 0f3c71824466 docs/README-data-partition.md: add documentation