### PR TITLE
Torizon rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This layer supports the following security features:
 
 The level of support of the above features is:
 
-- TorizonCore: tested and integrated.
+- Torizon: tested and integrated.
 - BSP Layers and Reference Images: not tested, integration effort is expected.
 
 The features are currently supported on the following SoMs:


### PR DESCRIPTION
Change the old TorizonCore name on our layer to the new Torizon OS.

Closes https://github.com/torizon/meta-toradex-torizon/issues/81