### PR TITLE
imx-boot-hab: Fix wrong U-Boot artifacts in case of multiple configs

### DIFF
--- a/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab.inc
+++ b/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab.inc
@@ -120,6 +120,10 @@ sign_common() {
                     UBOOT_DTB_NAME_EXTRA="${dtb_name}"
                 fi
                 BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+		UBOOT_NAME_EXTRA="u-boot-${MACHINE}.bin-${UBOOT_CONFIG_EXTRA}"
+
+		# Copy again artifacts for current U-Boot config to BOOT_STAGING
+		compile_${SOC_FAMILY}
 
 		case "$helper_type" in
 		    "habv4") sign_habv4_helper ;;


### PR DESCRIPTION
In do_compile of the imx-boot recipe the u-boot artifacts for the current
configuration are copied to ${BOOT_STAGING} directory by calling compile_${SOC_FAMILY}:
https://github.com/Freescale/meta-freescale/blob/fbea18dbdb750d567cbd8a4e73baed94ced02043/recipes-bsp/imx-mkimage/imx-boot_1.0.bb#L191

in imx-boot-hab.inc some targets are re-generated without copying the artifacts for the current U-Boot configuration
which means that always the artifacts e.g. u-boot-nodtb.bin from the last configuration type from the list is used.

Fix the issue by calling again compile_${SOC_FAMILY} in sign_common().

Fixes #36 