### PR TITLE
Improvements on the documentation, including the usage of TPMs for data-at-rest encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For more information on the available features, please check the corresponding d
 | [docs/README-optee.md](docs/README-optee.md) | Documentation on how to run a Trusted Execution Environment (OP-TEE) together with the Linux kernel |
 | [docs/README-data-partition.md](docs/README-data-partition.md) | Documentation on how to create an additional partition for storing persistent data |
 
-This layer only works on Toradex Embedded Linux 6.3.0 and newer releases.
+This layer only works on Toradex Embedded Linux BSP 6.3.0 and newer releases.
 
 # License
 

--- a/docs/README-encryption.md
+++ b/docs/README-encryption.md
@@ -10,6 +10,7 @@ Encryption is currently supported on the following SoMs:
 - Colibri iMX6ULL (1GB eMMC variant only)
 - Colibri iMX7D (1GB eMMC variant only)
 - Colibri iMX8X
+- Verdin AM62 (requires the availability of a TPM)
 - Verdin iMX8MM
 - Verdin iMX8MP
 
@@ -30,7 +31,9 @@ To solve this, a Linux kernel feature called [Trusted Keys](https://docs.kernel.
 
 Trusted Keys make it possible to create and manage variable-length symmetric keys in kernel space, and user space only sees, stores, and loads encrypted blobs.
 
-Trusted Keys require the availability of a Trust Source for greater security, and CAAM is leveraged on NXP iMX-based SoMs. TPM (Trusted Platform Module) and TEE (Trusted Execution Environment) are also two other possible trust sources for Trusted Keys, but currently not supported by this layer.
+Trusted Keys require the availability of a Trust Source for greater security. Different Trust Sources are supported, including CAAM (Cryptographic Acceleration and Assurance Module), TPM (Trusted Platform Module) and TEE (Trusted Execution Environment).
+
+This layer supports using CAAM and TPM as a source for managing the encryption key. CAAM is available on NXP iMX-based SoMs and TPM availability might depend on the selected SoM and carrier board.
 
 ## Block device encryption
 
@@ -52,17 +55,45 @@ Also, it is mandatory to set the `TDX_ENC_STORAGE_LOCATION` variable to the disk
 TDX_ENC_STORAGE_LOCATION = "/dev/sdb1"
 ```
 
-Here is the complete list of variables that can be used to customize the behavior of this feature:
+The `TDX_ENC_KEY_BACKEND` variable can be used to configure the trust source for managing the encryption key. If you plan to use CAAM on NXP iMX-based SoMs, you don't have to configure this variable, as it is automatically configured with `caam`. If you plan to use a TPM, you need to configure it as in the example below:
+
+```
+TDX_ENC_KEY_BACKEND:forcevariable = "tpm"
+```
+
+Make sure to use the `forcevariable` override, so your configuration takes precedence over the default one.
+
+A few additional variables are available to customize the behavior of the data-at-rest encryption feature. Here is the complete list:
 
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
-| TDX_ENC_KEY_BACKEND | Backend used to manage the encryption key. Allowed values: `caam` or `cleartext`. If configured with `caam`, it will use Trusted Keys backed by the CAAM device (available on NXP iMX-based SoMs). If configured with `cleartext`, the encryption key will be stored in clear text in the file system (use `cleartext` only for testing purposes!) | `caam` on iMX based SoMs, empty otherwise |
+| TDX_ENC_KEY_BACKEND | Backend used to manage the encryption key. Allowed values: `caam`, `tpm` or `cleartext`. If configured with `caam`, it will use Trusted Keys backed by the CAAM device (available on NXP iMX-based SoMs). If configured with `tpm`, it will use Trusted Keys backed by a TPM device (availability depends on the hardware). If configured with `cleartext`, the encryption key will be stored in clear text in the file system (use `cleartext` only for testing purposes!) | `caam` on iMX based SoMs, empty otherwise |
 | TDX_ENC_KEY_DIR | Directory to store the encryption key blob | `/var/local/private/.keys` |
 | TDX_ENC_KEY_FILE | File name of the encryption key blob | `tdx-enc-key.blob` |
 | TDX_ENC_STORAGE_LOCATION | Partition to be encrypted (e.g. `/dev/sdb1`) | Empty |
 | TDX_ENC_STORAGE_MOUNTPOINT | Directory to mount the encrypted partition | `/run/encdata` |
 
 IMPORTANT: The script that mounts the encrypted partition runs early in the boot process, where not necessarily udev has run/settled. For that reason, it is recommended to use the name of the partition as assigned by the kernel (e.g. `/dev/sdb1`). If one wants to set a name that relies on udev rules then one must review the systemd dependencies of the service to ensure the name is available.
+
+## Notes on using CAAM
+
+When the device is not closed (i.e. secure boot is not enabled), the CAAM backend will use a fixed test key to encrypt the encryption key. That makes it possible to test the encryption feature, but is certainly insecure and not recommended for production usage.
+
+When the device is closed (i.e. secure boot is enabled), the CAAM backend will use the OTPMK key (a never-disclosed 256-bit key randomly generated and fused into each SoC at manufacturing time). This is much more secure and recommended for production use cases.
+
+Be aware that, if you have a device with a partition encrypted with the test key, as soon as you enable secure boot and close the device, you will not be able to read the encrypted partition anymore. This is because CAAM will try to use the OTPMK key to decrypt the encryption key that was previously encrypted with the test key, and that will certainly not work.
+
+To workaround this issue, you can manually remove the key blob, which is by default located at `/var/local/private/.keys/tdx-enc-key.blob`. After removing the key blob and rebooting the device, another key will be generated and the partition will be formatted and encrypted with the new key. As a consequence, you will lose any content on the partition previously encrypted with the test key.
+
+## Notes on using a TPM
+
+Before enabling the TPM backend, you need to make sure there is a TPM device available in the hardware and configured in the operating system. This usually involves enabling the device driver in the Linux kernel and adding a node in the device tree. Be aware that providing access to a TPM device is out of scope in this layer.
+
+To confirm you have a TPM to be used as a Trust Source for managing the encryption key, you can check for the existence of the device node `/dev/tpm0`:
+
+```
+# ls -l /dev/tpm0
+```
 
 ## Encrypting a partition in the eMMC
 

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -54,6 +54,8 @@ For details on the bootloader signature checking implementation for SoMs that us
 
 ## U-Boot hardening
 
+**Important**: Currently, due to incompatibility with newer Toradex Embedded Linux BSP releases, the U-Boot hardening feature is not supported and is disabled by default (see [Issue #20](https://github.com/toradex/meta-toradex-security/issues/20)). This will be fixed in a future release of this layer.
+
 Toradex is implementing various changes to U-Boot (currently as a series of patches) with the purpose of hardening it for secure boot. The hardening includes the following features:
 
 - **Command whitelisting**: this part of the hardening is responsible for limiting the set of commands available to boot scripts once the device is in closed state - by default, only a small set of commands remain available in that state (mostly those strictly required for booting a secure boot image) alongside a few others considered strictly secure and potentially useful for future boot scripts.


### PR DESCRIPTION
Commits in this pull request:

- README-encryption.md: include information about the usage of TPMs
- README-secure-boot.md: mention that U-Boot hardening is currently not supported
- README.md: improve wording when referencing the BSP