### PR TITLE
Move toradex-nxp-layer and toradex-ti-layer to LAYERRECOMMENDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ revision: HEAD
 URI: git://git.yoctoproject.org/meta-security
 branch: kirkstone
 revision: HEAD
+```
 
+# Layer recommendations
+
+This layer recommends:
+
+```
 URI: git://git.toradex.com/meta-toradex-nxp.git
 branch: kirkstone
 revision: HEAD

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,9 +10,13 @@ BBFILE_PRIORITY_meta-toradex-security = "10"
 LAYERDEPENDS_meta-toradex-security = "\
     core \
     security \
+"
+
+LAYERRECOMMENDS_meta-toradex-security = "\
     toradex-nxp-layer \
     toradex-ti-layer \
 "
+
 LAYERSERIES_COMPAT_meta-toradex-security = "kirkstone"
 
 BBFILES_DYNAMIC += " \


### PR DESCRIPTION
I'm not sure if this works as I'm imagining it should but this PR "downgrades" `toradex-nxp-layer` and `toradex-ti-layer` from being "hard" dependency (`meta-toradex-security` won't build without both of these present) to a recommendation (this layer will build without but recommends both, this way you can also build using only one of these). 

Issue: https://github.com/toradex/meta-toradex-security/issues/50
