### PR TITLE
tdx-enc-handler: add support for saving the encryption key in the disk partition

### DIFF
--- a/classes/tdx-encrypted.bbclass
+++ b/classes/tdx-encrypted.bbclass
@@ -10,7 +10,15 @@ TDX_ENC_ENABLE = "1"
 TDX_ENC_KEY_BACKEND ?= ""
 TDX_ENC_KEY_BACKEND:imx-generic-bsp ?= "caam"
 
+# Encryption key blob location
+# This variable defines where the encrypted key will be stored
+# Available options:
+#    filesystem -> encrypted key blob is stored as a file in the filesystem
+#    partition  -> encrypted key blob is stored in a block of the disk outside the dm-crypt partition
+TDX_ENC_KEY_LOCATION ?= "filesystem"
+
 # directory to store the encryption key blob
+# required if the encryption key location is the filesystem
 TDX_ENC_KEY_DIR ?= "/var/local/private/.keys"
 
 # encryption key blob file name
@@ -24,6 +32,11 @@ TDX_ENC_STORAGE_TYPE ?= "partition"
 
 # Partition to be encrypted (e.g. /dev/sda1)
 TDX_ENC_STORAGE_LOCATION ?= ""
+
+# Number of blocks to reserve from the partition to be encrypted
+# Useful in case one needs a storage location to save data in raw
+# mode, outside the dm-drypt partition
+TDX_ENC_STORAGE_RESERVE ?= "0"
 
 # Defines where the encrypted storage will be mounted
 TDX_ENC_STORAGE_MOUNTPOINT ?= "/run/encdata"

--- a/docs/README-encryption.md
+++ b/docs/README-encryption.md
@@ -68,9 +68,11 @@ A few additional variables are available to customize the behavior of the data-a
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
 | TDX_ENC_KEY_BACKEND | Backend used to manage the encryption key. Allowed values: `caam`, `tpm` or `cleartext`. If configured with `caam`, it will use Trusted Keys backed by the CAAM device (available on NXP iMX-based SoMs). If configured with `tpm`, it will use Trusted Keys backed by a TPM device (availability depends on the hardware). If configured with `cleartext`, the encryption key will be stored in clear text in the file system (use `cleartext` only for testing purposes!) | `caam` on iMX based SoMs, empty otherwise |
+| TDX_ENC_KEY_LOCATION | Location to store the encryption key blob. Allowed values: `filesystem` or `partition`. If configured with `filesystem`, the encryption key blob will be stored as a file in the filesystem (location defined by the `TDX_ENC_KEY_DIR` variable. If configured with `partition`, the encryption key blob will be stored in a block of the disk outside the dm-crypt partition (useful if the rootfs filesystem is read-only) | `filesystem` |
 | TDX_ENC_KEY_DIR | Directory to store the encryption key blob | `/var/local/private/.keys` |
 | TDX_ENC_KEY_FILE | File name of the encryption key blob | `tdx-enc-key.blob` |
 | TDX_ENC_STORAGE_LOCATION | Partition to be encrypted (e.g. `/dev/sdb1`) | Empty |
+| TDX_ENC_STORAGE_RESERVE | Number of blocks to reserve from the partition to be encrypted. Each block is 512-byte in size. Might be useful in case one needs a storage location to save data in raw mode, outside the dm-drypt partition. If `TDX_ENC_KEY_LOCATION` is set to `partition`, then the first reserved block is used to store the encryption key blob. | `0` |
 | TDX_ENC_STORAGE_MOUNTPOINT | Directory to mount the encrypted partition | `/run/encdata` |
 
 IMPORTANT: The script that mounts the encrypted partition runs early in the boot process, where not necessarily udev has run/settled. For that reason, it is recommended to use the name of the partition as assigned by the kernel (e.g. `/dev/sdb1`). If one wants to set a name that relies on udev rules then one must review the systemd dependencies of the service to ensure the name is available.

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
@@ -32,8 +32,10 @@ do_install() {
     install -m 0755 ${WORKDIR}/tdx-enc.sh ${D}${sbindir}/tdx-enc.sh
 
     sed -i 's|@@TDX_ENC_KEY_BACKEND@@|${TDX_ENC_KEY_BACKEND}|g' ${D}${sbindir}/tdx-enc.sh
+    sed -i 's|@@TDX_ENC_KEY_LOCATION@@|${TDX_ENC_KEY_LOCATION}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_KEY_FILE@@|${TDX_ENC_KEY_FILE}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_STORAGE_LOCATION@@|${TDX_ENC_STORAGE_LOCATION}|g' ${D}${sbindir}/tdx-enc.sh
+    sed -i 's|@@TDX_ENC_STORAGE_RESERVE@@|${TDX_ENC_STORAGE_RESERVE}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_STORAGE_MOUNTPOINT@@|${TDX_ENC_STORAGE_MOUNTPOINT}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_KEY_DIR@@|${TDX_ENC_KEY_DIR}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_PRESERVE_DATA@@|${TDX_ENC_PRESERVE_DATA}|g' ${D}${sbindir}/tdx-enc.sh


### PR DESCRIPTION
On systems with secure boot enabled and an encrypted data partition, there is no place to store the encryption key blob, since the rootfs will be read-only (because of dm-verity) and one cannot use the data partition to store the key required to decrypt itself.

To solve this issue, let's make it possible to save the encryption key blob inside the encrypted partition, in a reserved block in raw mode.

When enabled (`TDX_ENC_KEY_LOCATION="partition"`), the last block of the partition to be encrypted will be reserved to store the encryption key blob, using the following format, where SIZE is a 3-bytes string representing the size of the key and KEY is the content of the encryption key blob:

```
'ENCKEY' + 'SIZE(3)' + KEY(N)
```

The default behavior is still to save the key as a file in the filesystem (`TDX_ENC_KEY_LOCATION="filesystem"`), so this feature will not break systems that are currently using encryption.