### PR TITLE
u-boot: display warnings on disallowed commands (kirkstone)

### DIFF
--- a/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
@@ -1,4 +1,4 @@
-From 90474be140b1898670bd6e23e27cca6be4deb57c Mon Sep 17 00:00:00 2001
+From 39ebb14f545ffaa15661d194f028213002a8a497 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:28:50 -0300
 Subject: [PATCH 1/8] toradex: common: add command whitelisting modules
@@ -11,10 +11,10 @@ Upstream-Status: Inappropriate [TorizonCore specific]
 Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 ---
  common/tdx-harden.c                           | 260 ++++++
- common/whitelist.c                            | 815 ++++++++++++++++++
+ common/whitelist.c                            | 841 ++++++++++++++++++
  .../dt-bindings/secure-boot/cmd-categories.h  | 101 +++
  include/tdx-harden.h                          |  42 +
- 4 files changed, 1218 insertions(+)
+ 4 files changed, 1244 insertions(+)
  create mode 100644 common/tdx-harden.c
  create mode 100644 common/whitelist.c
  create mode 100644 include/dt-bindings/secure-boot/cmd-categories.h
@@ -288,10 +288,10 @@ index 00000000000..fb8aaa5eed0
 +#endif
 diff --git a/common/whitelist.c b/common/whitelist.c
 new file mode 100644
-index 00000000000..a60f62d5863
+index 00000000000..e5047f5d626
 --- /dev/null
 +++ b/common/whitelist.c
-@@ -0,0 +1,815 @@
+@@ -0,0 +1,841 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright 2023 Toradex
@@ -991,10 +991,13 @@ index 00000000000..a60f62d5863
 +/**
 + * on_cmd_execution_denied - Handle command execution denials
 + */
-+static void on_cmd_execution_denied(int argc,
-+				    char *const argv[], char *const reason)
++static void on_cmd_execution_denied(int simulated,
++				    int argc, char *const argv[],
++				    char *const reason)
 +{
-+	puts("Command execution denied (");
++	puts("## WARNING: Command execution ");
++	puts(simulated ? "WOULD BE DENIED in closed state" : "denied");
++	puts(" (");
 +	puts(reason);
 +	puts(") for `");
 +	for (int i = 0; i < argc; i++) {
@@ -1021,59 +1024,25 @@ index 00000000000..a60f62d5863
 +}
 +
 +/**
-+ * cmd_allowed_by_whitelist - Check if command execution is allowed by whitelist
++ * cmd_allowed_by_whitelist_idx - Check if command execution is allowed
 + *
-+ * @cmdtp: Pointer to the command to execute
-+ * @argc: Number of arguments (arg 0 must be the command text)
-+ * @argv: Arguments (include command name at index 0)
-+ * Return: 1 if command is allowed or 0 otherwise
++ * @device_is_open: Device state
++ * @found_ind: Index of command in whitelist table
 + */
-+int cmd_allowed_by_whitelist(struct cmd_tbl *cmd, int argc, char *const argv[])
++static int cmd_allowed_by_whitelist_idx(int device_is_open, int found_ind)
 +{
-+	int rbeg, rend;
-+	int allow = 0, device_is_open = 0, found_ind = -1;
-+	const struct cmd_whitelist_entry *wle = NULL;
++	const struct cmd_whitelist_entry *wle = &cmd_whitelist[found_ind];
++	int allow = 0;
 +
-+	if (!cmd_whitelist_enabled(&device_is_open)) {
-+		/* Whitelist feature disabled (at runtime). */
-+		return 1;
-+	}
-+	if (!gd->fdt_blob) {
-+		printf("whitelist feature requires a valid FDT blob\n");
-+		return 1;
-+	}
-+
-+	if (!find_range_in_whitelist(cmd->name, &rbeg, &rend)) {
-+		/* Command name not in whitelist: deny execution. */
-+		on_cmd_execution_denied(argc, argv, "name not in whitelist");
-+		return 0;
-+	}
-+
-+	/* Find first entry matching command arguments. */
-+	for (int ind = rbeg; ind <= rend; ind++) {
-+		if (args_match_whitelist_entry(argc, argv, ind)) {
-+			found_ind = ind;
-+			break;
-+		}
-+	}
-+	if (found_ind < 0) {
-+		/* Specific command format not in whitelist: deny execution. */
-+		on_cmd_execution_denied(argc, argv, "format not in whitelist");
-+		return 0;
-+	}
-+
-+	/* Check the command categories against the allowed/denied ones. */
-+	wle = &cmd_whitelist[found_ind];
-+
-+	if (!allow &&
-+	    find_category_in_fdt(
++	if (find_category_in_fdt(
 +		    wle->categories, WHITELIST_MAX_CMD_CATEGORIES,
 +		    bootldr_cmds_node_path,
 +		    (device_is_open ? "allow-open" : "allow-closed"),
 +		    (device_is_open ?
 +		     default_allowed_categories_open :
 +		     default_allowed_categories_closed))) {
-+		debug("Entry %d passed categories whitelist\n", found_ind);
++		debug("Entry %d passed categories whitelist when %s\n",
++		      found_ind, device_is_open ? "open" : "closed");
 +		allow = 1;
 +	}
 +
@@ -1085,7 +1054,8 @@ index 00000000000..a60f62d5863
 +		    (device_is_open ?
 +		     default_denied_categories_open :
 +		     default_denied_categories_closed))) {
-+		debug("Entry %d blocked by categories blacklist\n", found_ind);
++		debug("Entry %d blocked by categories blacklist when %s\n",
++		      found_ind, device_is_open ? "open" : "closed");
 +		allow = 0;
 +	}
 +
@@ -1099,10 +1069,66 @@ index 00000000000..a60f62d5863
 +		allow = 1;
 +	}
 +
++	return allow;
++}
++
++/**
++ * cmd_allowed_by_whitelist - Check if command execution is allowed by whitelist
++ *
++ * @cmdtp: Pointer to the command to execute
++ * @argc: Number of arguments (arg 0 must be the command text)
++ * @argv: Arguments (include command name at index 0)
++ * Return: 1 if command is allowed or 0 otherwise
++ */
++int cmd_allowed_by_whitelist(struct cmd_tbl *cmd, int argc, char *const argv[])
++{
++	int rbeg, rend;
++	int allow = 0, device_is_open = 0, found_ind = -1;
++
++	if (!cmd_whitelist_enabled(&device_is_open)) {
++		/* Whitelist feature disabled (at runtime). */
++		return 1;
++	}
++	if (!gd->fdt_blob) {
++		printf("whitelist feature requires a valid FDT blob\n");
++		return 1;
++	}
++
++	if (!find_range_in_whitelist(cmd->name, &rbeg, &rend)) {
++		/* Command name not in whitelist: deny execution. */
++		on_cmd_execution_denied(0, argc, argv, "name not in whitelist");
++		return 0;
++	}
++
++	/* Find first entry matching command arguments. */
++	for (int ind = rbeg; ind <= rend; ind++) {
++		if (args_match_whitelist_entry(argc, argv, ind)) {
++			found_ind = ind;
++			break;
++		}
++	}
++	if (found_ind < 0) {
++		/* Specific command format not in whitelist: deny execution. */
++		on_cmd_execution_denied(0, argc, argv, "format not in whitelist");
++		return 0;
++	}
++
++	/* Check the command categories against the allowed/denied ones. */
++	allow = cmd_allowed_by_whitelist_idx(device_is_open, found_ind);
 +	if (!allow) {
-+		/* Some command category is not the whitelist */
++		/* Some command category is not in the whitelist */
 +		/* or is present in the blacklist. */
-+		on_cmd_execution_denied(argc, argv, "blocked by category");
++		on_cmd_execution_denied(0, argc, argv, "blocked by category");
++	}
++
++	if (device_is_open) {
++		/* Determine if command would be allowed if the device were */
++		/* in closed state; let user know if not so they don't */
++		/* inadvertently close it leaving the device unbootable. */
++		int allow_when_closed = cmd_allowed_by_whitelist_idx(0, found_ind);
++		if (!allow_when_closed) {
++			on_cmd_execution_denied(1, argc, argv, "blocked by category");
++		}
 +	}
 +
 +	return allow;


### PR DESCRIPTION
With this implementation that is part of the hardening, U-Boot will show warning messages informing the users when a command that is accepted in open state would not be allowed when the device is closed. This is useful to let users know that closing the device would likely leave it in an unbootable state if any of the commands is part of their boot script.

Resolves #23

As an example of how this helps, running with the present implementation on a BSP image produces an output like this:

```
## WARNING: Command execution WOULD BE DENIED in closed state (blocked by category) for `part uuid mmc 0:2...`.
```

which shows that the boot script of a BSP image is running the "part uuid" command which would not be allowed in closed state; solving this will be the topic of an upcoming implementation.

IMPORTANT:

- Since the hardening is implemented as a series of patches, it may be easier to review/understand the changes in this dummy pull request (where the relevant changes are in the last commit): https://github.com/rborn-tx/u-boot/pull/1
