### PR TITLE
Enable hardening on BSP images (kirkstone)

### DIFF
--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -9,17 +9,10 @@
 # combination UBOOT_SIGN_ENABLE="0" TDX_UBOOT_HARDENING_ENABLE="1" is not very
 # helpful and can prevent the loading of non-FIT images.
 #
-# Moreover, currently the hardening is tested only with Torizon OS and it's
-# not expected to work out of the box with BSP images.
-#
-# Because of the above, we enable the hardening only when building Torizon OS
-# images provided that both TDX_IMX_HAB_ENABLE and UBOOT_SIGN_ENABLE are set, by
-# default.
+# Because of the above, we enable the hardening only when TDX_IMX_HAB_ENABLE and
+# UBOOT_SIGN_ENABLE are set, by default.
 #
 def default_tdx_uboot_hardening_enable(d):
-    # TODO: Remove this condition once support for BSP images is added.
-    if "torizon" not in d.getVar("OVERRIDES").split(":"):
-        return False
     if (bb.utils.to_boolean(d.getVar('TDX_IMX_HAB_ENABLE')) and
         bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE'))):
         return True
@@ -27,34 +20,20 @@ def default_tdx_uboot_hardening_enable(d):
 
 TDX_UBOOT_HARDENING_ENABLE ?= "${@'1' if default_tdx_uboot_hardening_enable(d) else '0'}"
 
-# Configure one of the hardening features: the "bootargs protection"; with this
-# protection, the fixed part of the kernel command line (boot arguments) are
-# saved into the FIT image and checked against the "bootargs" environment
-# variable at runtime (by U-Boot).
+# Configure the "kernel command-line protection"; with this protection, the
+# fixed part of the bootargs are saved into the FIT image and checked against
+# the "bootargs" environment variable at runtime (by U-Boot).
 #
-# Notice that the values set below are appropriate for booting Torizon OS only;
-# this will be changed in the future.
-#
-# TODO: Set TDX_SECBOOT_REQUIRED_BOOTARGS differently based on overrides
-# "tdx-signed" or "torizon-signed"; the former for booting the BSP reference
-# image and the latter for Torizon OS.
-#
-# NOTE: TDX_SECBOOT_REQUIRED_BOOTARGS_COMMON should be kept in sync with
-#       OSTREE_KERNEL_ARGS from layer meta-toradex-torizon (this is not done
-#       here because meta-toradex-security does not depend on that layer).
-#
+# TODO: Ensure bootargs are set correctly on all machines.
 TDX_SECBOOT_REQUIRED_BOOTARGS ?= ""
-TDX_SECBOOT_REQUIRED_BOOTARGS_COMMON = "quiet logo.nologo vt.global_cursor_default=0 plymouth.ignore-serial-consoles splash fbcon=map:3"
-TDX_SECBOOT_REQUIRED_BOOTARGS_COMMON:append:cfs-support = " systemd.gpt_auto=0"
-
-TDX_SECBOOT_REQUIRED_BOOTARGS:imx-generic-bsp = "root=LABEL=otaroot rootfstype=ext4 ${TDX_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-TDX_SECBOOT_REQUIRED_BOOTARGS:apalis-imx8 = "pci=nomsi root=LABEL=otaroot rootfstype=ext4 ${TDX_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-TDX_SECBOOT_REQUIRED_BOOTARGS:apalis-imx6 = "enable_wait_mode=off vmalloc=400M root=LABEL=otaroot rootfstype=ext4 ${TDX_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx6 = "enable_wait_mode=off galcore.contiguousSize=50331648 root=LABEL=otaroot rootfstype=ext4 ${TDX_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx6ull-emmc = "user_debug=30 root=LABEL=otaroot rootfstype=ext4 ${TDX_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-
-TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-am62 = ""
-TDX_SECBOOT_REQUIRED_BOOTARGS:qemuarm64 = ""
+TDX_SECBOOT_REQUIRED_BOOTARGS:apalis-imx6 ?= "ro rootwait console=tty1 console=ttymxc0,115200"
+TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx6 ?= "ro rootwait console=tty1 console=ttymxc0,115200"
+TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx6ull-emmc ?= "user_debug=30 ro rootwait console=tty1 console=ttymxc0,115200n8 consoleblank=0"
+TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx7 ?= "ro rootwait console=tty1 console=ttymxc0,115200n8 consoleblank=0"
+TDX_SECBOOT_REQUIRED_BOOTARGS:apalis-imx8 ?= "ro rootwait console=tty1 console=ttyLP1,115200 consoleblank=0 earlycon"
+TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mm ?= "ro rootwait console=tty1 console=ttymxc0,115200 consoleblank=0 earlycon"
+TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mp ?= "ro rootwait console=tty1 console=ttymxc2,115200 consoleblank=0 earlycon"
+TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx8x ?= "ro rootwait console=tty1 console=ttyLP3,115200 consoleblank=0 earlycon"
 
 # Name of the overlay file (without extension) that will contain the fixed part
 # of the kernel command line; this will be stored inside the FIT image; notice

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -54,8 +54,6 @@ For details on the bootloader signature checking implementation for SoMs that us
 
 ## U-Boot hardening
 
-**Important**: Currently, due to incompatibility with newer Toradex Embedded Linux BSP releases, the U-Boot hardening feature is not supported and is disabled by default (see [Issue #20](https://github.com/toradex/meta-toradex-security/issues/20)). This will be fixed in a future release of this layer.
-
 Toradex is implementing various changes to U-Boot (currently as a series of patches) with the purpose of hardening it for secure boot. The hardening includes the following features:
 
 - **Command whitelisting**: this part of the hardening is responsible for limiting the set of commands available to boot scripts once the device is in closed state - by default, only a small set of commands remain available in that state (mostly those strictly required for booting a secure boot image) alongside a few others considered strictly secure and potentially useful for future boot scripts.
@@ -67,10 +65,9 @@ The hardening features above are controlled by the following variables:
 
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
-| `TDX_UBOOT_HARDENING_ENABLE` | Enable hardening features as a whole | `1` if building a Torizon OS image with both `TDX_IMX_HAB_ENABLE` and `UBOOT_SIGN_ENABLE` set; `0` otherwise |
-| `TDX_SECBOOT_REQUIRED_BOOTARGS` | Expected value for the fixed part of the kernel command line | Different value for each machine (suitable for Torizon OS) |
-
-Obs.: Currently, U-Boot hardening is enabled by default only when building the Torizon OS.
+| `TDX_UBOOT_HARDENING_ENABLE` | Enable hardening features as a whole | `1` if both `TDX_IMX_HAB_ENABLE` and `UBOOT_SIGN_ENABLE` are set; `0` otherwise |
+| `TDX_SECBOOT_REQUIRED_BOOTARGS` | Expected value for the fixed part of the kernel command line | Different value for each machine |
+| `TDX_AMEND_BOOT_SCRIPT` | When set to `1` the boot script will be amended to make it suitable for secure boot; this only works with the script provided by Toradex for BSP reference images; users employing a custom script should set this to `0` | Same value as variable `TDX_UBOOT_HARDENING_ENABLE` |
 
 The behavior of the different hardening features can be set via the control FDT (see [Devicetree Control in U-Boot](https://u-boot.readthedocs.io/en/stable/develop/devicetree/control.html)). Setting the control FDT at build time can be achieved by adding extra device-tree [.dtsi fragments](https://u-boot.readthedocs.io/en/stable/develop/devicetree/control.html#external-dtsi-fragments) to U-Boot and setting the Kconfig variable `CONFIG_DEVICE_TREE_INCLUDES` appropriately; with Yocto/OE this would normally involve adding small patches to U-Boot and appending changes to its recipe but the details are outside the scope of the present document.
 
@@ -135,3 +132,7 @@ When `tdxref-signed` is used to enable secure boot, the rootfs image is generate
 Because `dm-verity` is read-only, you might want to create an additional partition in the eMMC to store persistent data.
 
 If that is the case, you can use the `tdx-tezi-data-partition` class. For more information, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).
+
+## Known issues and limitations
+
+- Currently the hardening is implemented/integrated on NXP SoCs only; when building for other SoC vendors one has to disable the feature (set `TDX_UBOOT_HARDENING_ENABLE=` to `0`) or the build will fail.

--- a/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
@@ -1,4 +1,4 @@
-From 39ebb14f545ffaa15661d194f028213002a8a497 Mon Sep 17 00:00:00 2001
+From 48a9bffb1528563e8eca3e3774d9f409d51f47d7 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:28:50 -0300
 Subject: [PATCH 1/8] toradex: common: add command whitelisting modules
@@ -288,7 +288,7 @@ index 00000000000..fb8aaa5eed0
 +#endif
 diff --git a/common/whitelist.c b/common/whitelist.c
 new file mode 100644
-index 00000000000..e5047f5d626
+index 00000000000..462df6709d2
 --- /dev/null
 +++ b/common/whitelist.c
 @@ -0,0 +1,841 @@
@@ -599,7 +599,7 @@ index 00000000000..e5047f5d626
 +	{ { "nfs", ALL }, { CMD_CAT_EXEC, CMD_CAT_MEM_WRITE } },
 +	{ { "nm", ALL }, { CMD_CAT_MEM_READ, CMD_CAT_MEM_WRITE } },
 +	{ { "panic", ALL }, { CMD_CAT_SAFE } },
-+	{ { "part", "uuid", ALL }, { CMD_CAT_PART_READ } },
++	{ { "part", "uuid", ALL }, { CMD_CAT_PART_READ, CMD_CAT_NEEDED } },
 +	{ { "part", "list", ALL }, { CMD_CAT_PART_READ, CMD_CAT_NEEDED } },
 +	{ { "part", "start", ALL }, { CMD_CAT_PART_READ } },
 +	{ { "part", "size", ALL }, { CMD_CAT_PART_READ } },

--- a/recipes-bsp/u-boot/files/0007-toradex-add-implementation-of-bootargs-protection.patch
+++ b/recipes-bsp/u-boot/files/0007-toradex-add-implementation-of-bootargs-protection.patch
@@ -1,4 +1,4 @@
-From e607277dac5e54186e2b287c696924b443ba1fc2 Mon Sep 17 00:00:00 2001
+From 242b368c9a84863984e6f787762100af03298f10 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 6 Nov 2023 22:25:28 -0300
 Subject: [PATCH 7/8] toradex: add implementation of bootargs protection
@@ -10,12 +10,12 @@ Upstream-Status: Inappropriate [TorizonCore specific]
 
 Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 ---
- common/tdx-harden.c  | 197 +++++++++++++++++++++++++++++++++++++++++++
+ common/tdx-harden.c  | 231 +++++++++++++++++++++++++++++++++++++++++++
  include/tdx-harden.h |   9 +-
- 2 files changed, 204 insertions(+), 2 deletions(-)
+ 2 files changed, 238 insertions(+), 2 deletions(-)
 
 diff --git a/common/tdx-harden.c b/common/tdx-harden.c
-index 1134b6ce596..c4963c0868c 100644
+index 1134b6ce596..4061bc85eac 100644
 --- a/common/tdx-harden.c
 +++ b/common/tdx-harden.c
 @@ -3,12 +3,18 @@
@@ -37,7 +37,7 @@ index 1134b6ce596..c4963c0868c 100644
  #include <asm/global_data.h>
  #include <tdx-harden.h>
  
-@@ -42,6 +48,33 @@ enum dbg_hab_status_t dbg_hab_status = DBG_HAB_STATUS_AUTO;
+@@ -42,6 +48,36 @@ enum dbg_hab_status_t dbg_hab_status = DBG_HAB_STATUS_AUTO;
  enum dbg_hdn_status_t dbg_hdn_status = DBG_HDN_STATUS_AUTO;
  #endif
  
@@ -49,19 +49,22 @@ index 1134b6ce596..c4963c0868c 100644
 +	BPARAM_NONE,
 +	BPARAM_INTEGER,
 +	BPARAM_OSTREE_PATH,
++	BPARAM_GENERIC_UUID,
 +};
 +
 +struct bootarg_spec_t {
 +	const char *param;
 +	enum bootarg_param_type_t type;
++	const char *conflict;
 +};
 +
 +static const struct bootarg_spec_t bootarg_spec[] = {
-+	{ "ostree=", BPARAM_OSTREE_PATH },
++	{ "ostree=", BPARAM_OSTREE_PATH, NULL },
++	{ "root=PARTUUID=", BPARAM_GENERIC_UUID, "root=" }
 +#if 0
 +	/* Examples */
-+	{ "loglevel=", BPARAM_INTEGER },
-+	{ "nowb", BPARAM_NONE },
++	{ "loglevel=", BPARAM_INTEGER, NULL },
++	{ "nowb", BPARAM_NONE, NULL },
 +#endif
 +};
 +
@@ -71,13 +74,13 @@ index 1134b6ce596..c4963c0868c 100644
  static int _tdx_hardening_enabled(void)
  {
  	const void *dis_prop;
-@@ -210,6 +243,170 @@ void tdx_secure_boot_cmd(const char *cmd)
+@@ -210,6 +246,201 @@ void tdx_secure_boot_cmd(const char *cmd)
  }
  #endif
  
 +#ifdef CONFIG_TDX_BOOTARGS_PROTECTION
 +/**
-+ * _tdx_valid_var_bootargs - Check single argument in bootargs
++ * _tdx_valid_var_bootarg - Check single argument in bootargs
 + *
 + * TODO: Add support for quoted strings.
 + */
@@ -107,6 +110,14 @@ index 1134b6ce596..c4963c0868c 100644
 +			return 0;
 +		break;
 +	}
++	case BPARAM_GENERIC_UUID: {
++		/* Accept hex digits and dashes. */
++		while (isxdigit(*valp) || *valp == '-')
++			valp++;
++		if (valp == value)
++			return 0;
++		break;
++	}
 +	default:
 +		printf("Unhandled bootarg param type %d\n", (int) type);
 +		return 0;
@@ -125,7 +136,7 @@ index 1134b6ce596..c4963c0868c 100644
 +/**
 + * _tdx_valid_var_bootargs - Check the variable part of bootargs
 + */
-+static int _tdx_valid_var_bootargs(const char *bootargs)
++static int _tdx_valid_var_bootargs(const char *bootargs, const char *reqargs)
 +{
 +	const char *args = bootargs, *value = NULL, *eptr;
 +
@@ -140,7 +151,7 @@ index 1134b6ce596..c4963c0868c 100644
 +			}
 +		}
 +		if (bi >= BOOTARG_SPEC_LEN) {
-+			printf("## Unexpected argument in bootargs: "
++			printf("## Unexpected argument in variable bootargs: "
 +			       "%.16s...\n", args);
 +			return 0;
 +		}
@@ -149,6 +160,29 @@ index 1134b6ce596..c4963c0868c 100644
 +			printf("## Argument validation failed for bootarg "
 +			       "%.16s...\n", args);
 +			return 0;
++		}
++
++		/* Check if the parameter specified in the variable part conflicts
++                   with a parameter in the required (fixed) part; this prevents
++                   parameters to be overriden in the variable part when they are
++                   supposed to be present only in the fixed part of the bootargs. */
++		if (bootarg_spec[bi].conflict) {
++			const char *reqptr = strstr(reqargs, bootarg_spec[bi].conflict);
++			int conflict = 0;
++			if (reqptr && reqptr == reqargs) {
++				/* found at the beginning of the reqargs. */
++				conflict = 1;
++
++			} else if (reqptr && reqptr != reqargs) {
++				/* found not at the beginning: confirm. */
++				reqptr--;
++				if (isspace(*reqptr)) conflict = 1;
++			}
++			if (conflict) {
++				printf("## Conflicting argument in variable bootargs: "
++				       "%.16s...\n", args);
++				return 0;
++			}
 +		}
 +
 +		args = eptr;
@@ -216,7 +250,7 @@ index 1134b6ce596..c4963c0868c 100644
 +	}
 +
 +	debug("variable part to validate: \"%s\"\n", args);
-+	if (!_tdx_valid_var_bootargs(args))
++	if (!_tdx_valid_var_bootargs(args, req_args))
 +		goto varpart_invalid;
 +
 +	return 1;

--- a/recipes-bsp/u-boot/u-boot-distro-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-distro-boot-harden.inc
@@ -1,12 +1,12 @@
 # When hardening is enabled, ask for the use of the overlay containing the
 # "secure" bootargs. Here we assume an underlying layer will provide this
 # capabitlity of applying predefined overlays inside the FIT image based on
-# variable DISTRO_BOOT_PREDEF_FITCONF; such capability would normally rely
-# on the boot script.
+# variable FITCONF_FDT_OVERLAYS; such capability would normally rely on the
+# boot script.
 #
 # For Torizon OS, the handling of predefined overlays is done by the
-# u-boot-distro-boot recipe provided by layer meta-toradex-torizon.
+# u-boot-distro-boot recipe provided by layer meta-toradex-torizon, whereas
+# for Toradex BSP Reference images, this is done by the u-boot-distro-boot
+# recipe provided by layer meta-toradex-bsp-common.
 #
-# TODO: Handle this variable also in the BSP layer.
-#
-DISTRO_BOOT_PREDEF_FITCONF .= "${@oe.utils.conditional('TDX_UBOOT_HARDENING_ENABLE', '1', '#conf-${TDX_SECBOOT_KARGS_OVERLAY}.dtbo', '', d)}"
+FITCONF_FDT_OVERLAYS .= "${@oe.utils.conditional('TDX_UBOOT_HARDENING_ENABLE', '1', '#conf-${TDX_SECBOOT_KARGS_OVERLAY}.dtbo', '', d)}"

--- a/recipes-bsp/u-boot/u-boot-distro-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-distro-boot-harden.inc
@@ -10,3 +10,77 @@
 # recipe provided by layer meta-toradex-bsp-common.
 #
 FITCONF_FDT_OVERLAYS .= "${@oe.utils.conditional('TDX_UBOOT_HARDENING_ENABLE', '1', '#conf-${TDX_SECBOOT_KARGS_OVERLAY}.dtbo', '', d)}"
+
+# Whether or not to amend the boot script (this only works with the Toradex-
+# provided boot script for BSP images); users utilizing a custom boot script
+# would likely set this variable to "0".
+TDX_AMEND_BOOT_SCRIPT ?= "${TDX_UBOOT_HARDENING_ENABLE}"
+
+# Whether the baudrate is missing from the U-Boot console environment variable.
+# When it is missing we append the baudrate variable into the console one when
+# amending the boot script.
+CONSOLE_BAUDRATE_MISSING ?= "1"
+
+amend_console_argument() {
+    # Look for a line like this:
+    # > env set setupargs ...console=${console}
+    # That we may modify depending on CONSOLE_BAUDRATE_MISSING.
+    if ! grep -q '^ *env set setupargs.*\bconsole=' boot.cmd; then
+        bbfatal "Amendments to bootscript must be reviewed: line setting the 'setupargs' variable has not been found."
+    fi
+
+    if [ "${CONSOLE_BAUDRATE_MISSING}" = "1" ]; then
+        sed -e '/env set setupargs .*\bconsole=\$''{console}\($''\|\s\)/{s#\bconsole\b=\$''{console}#console=\$''{console},$''{baudrate}#}' \
+            -i boot.cmd
+    fi
+}
+
+amend_root_argument() {
+    # The goal of the following script is to turn a line like this:
+    #
+    # env set rootfsargs_set 'env set rootfsargs "  sarg1=sarg1 darg1=$darg1   darg2=$darg2    sarg2=sarg2"'
+    #
+    # into this:
+    #
+    # env set rootfsargs_set 'env set rootfsargs1 "sarg1=sarg1 sarg2=sarg2" && env set rootfsargs2 "darg1=$darg1 darg2=$darg2"'
+    #
+    # i.e. it breaks down rootfsargs into static (rootfsargs1) and dynamic
+    # arguments (rootfsargs2).
+    sed -e "
+        /env set rootfsargs_set/ {
+            s/^\(.*\)env set rootfsargs \"\(.*\)\"\('.*\)$/\2 \nS:\nD:\n\1\n\3/
+            :l1
+            s/^ \+//; t l1
+            s/^\([^\n \$]\+\) \(.*\nS:[^\n]*\)\(.*\)$/\2 \1\3/; t l1
+            s/^\([^\n \$]*\$[^\n ]\+\) \(.*\nD:[^\n]*\)\(.*\)$/\2 \1\3/; t l1
+            s/.*\nS: *\([^\n]*\)\nD: *\([^\n]*\)\n\([^\n]*\)\n\([^\n]*\)/\3env set rootfsargs1 \"\1\" \&\& env set rootfsargs2 \"\2\"\4/
+        }" \
+    	-i boot.cmd
+
+    # Use the splitted rootfsargs keeping the static part at the beginning and
+    # the dynamic part at the end of the bootargs variable. For this, the following
+    # script will turn:
+    #
+    # env set bootcmd_args 'run rootfsargs_set && env set bootargs ${defargs} ${rootfsargs} ${setupargs} ${vidargs} ${tdxargs}'
+    #                                                                         ^^^^^^^^^^^^^
+    # into:
+    #
+    # env set bootcmd_args 'run rootfsargs_set && env set bootargs ${defargs} ${rootfsargs1} ${setupargs} ${vidargs} ${tdxargs} ${rootfsargs2} '
+    #                                                                         ^^^^^^^^^^^^^^                                    ^^^^^^^^^^^^^^
+    sed -e '
+        /^env set bootcmd_args/ {
+            s/env set bootargs \$''{defargs} \$''{rootfsargs} \$''{setupargs} \$''{vidargs} \$''{tdxargs}/env set bootargs \$''{defargs} \$''{rootfsargs1} \$''{setupargs} \$''{vidargs} \$''{tdxargs} \$''{rootfsargs2}/
+        }' \
+    	-i boot.cmd
+
+    if [ "$(grep 'rootfsargs[^12_]' boot.cmd | wc -l)" -ne 0 ]; then
+        bbfatal "Amendments to bootscript must be reviewed: there are unhandled occurrences of variable 'rootfsargs'."
+    fi
+}
+
+do_compile:append() {
+    if [ "${TDX_AMEND_BOOT_SCRIPT}" = "1" ]; then
+        amend_console_argument
+        amend_root_argument
+    fi
+}

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -26,8 +26,4 @@ do_compile:prepend() {
     if [ "${TDX_IMX_HAB_ENABLE}" = "0" ] && [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
         bbfatal 'The combination TDX_IMX_HAB_ENABLE = "0" and TDX_UBOOT_HARDENING_ENABLE = "1" is not allowed: the whitelisting feature (part of the hardening) currently relies on HAB/AHAB.'
     fi
-    if [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ] && \
-       [ "${@'1' if any(_d in d.getVar('OVERRIDES').split(':') for _d in ['torizon', 'torizon-upstream']) else '0'}" != "1" ]; then
-        bbfatal 'U-Boot hardening feature (enabled by TDX_UBOOT_HARDENING_ENABLE=1) is currently tested with Torizon OS only and is not expected to work with BSP images.'
-    fi
 }


### PR DESCRIPTION
Same as https://github.com/toradex/meta-toradex-security/pull/63 but adapted to `kirkstone`.

NOTE: Leaving as draft until BSP changes are merged in.