### PR TITLE
Fixes to support secure boot on AM62

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fit-signature-ti.inc
+++ b/recipes-bsp/u-boot/u-boot-fit-signature-ti.inc
@@ -1,9 +1,21 @@
-do_deploy:prepend() {
-    # when the FIT image is generated and signed, the public key is included
-    # in u-boot.dtb, and the U-boot image needs to be regenerated so the new
-    # DTB is used
+rebuild_uboot() {
     eval $(cat include/config/auto.conf | grep ^CONFIG_DEFAULT_DEVICE_TREE)
     install -m 0644 u-boot.dtb arch/arm/dts/${CONFIG_DEFAULT_DEVICE_TREE}.dtb
     oe_runmake ${UBOOT_MAKE_TARGET}
     install -m 0644 ${UBOOT_BINARY} u-boot-${UBOOT_CONFIG}.img
+}
+
+do_deploy:prepend() {
+    # when the FIT image is generated and signed, the public key is included
+    # in u-boot.dtb, and the U-boot image needs to be regenerated so the new
+    # DTB is used
+    if [ -n "${UBOOT_CONFIG}" ]; then
+        for config in ${UBOOT_MACHINE}; do
+            cd ${B}/${config}
+            rebuild_uboot
+        done
+    else
+        cd ${B}
+        rebuild_uboot
+    fi
 }

--- a/recipes-bsp/u-boot/u-boot-hsse.inc
+++ b/recipes-bsp/u-boot/u-boot-hsse.inc
@@ -1,8 +1,8 @@
 update_signing_keys() {
-    rm -Rf ${S}/board/ti/keys
-    ln -s ${TDX_K3_HSSE_KEY_DIR} ${S}/board/ti/keys
+    rm -Rf ${S}/arch/arm/mach-k3/keys
+    ln -s ${TDX_K3_HSSE_KEY_DIR} ${S}/arch/arm/mach-k3/keys
 }
 
 do_unpack:append() {
-    bb.build.exec_func('update_signing_keys', d)    
+    bb.build.exec_func('update_signing_keys', d)
 }


### PR DESCRIPTION
A couple of fixes are required to have secure boot support on AM62 in the scarthgap branch.

Tested on AM62 with the keys fused, full chain-of-trust is working as expected.

Commits in this PR:

- ac817f4e3280 u-boot: ti: change logic to rebuild U-Boot
- bd4fc55f6727 u-boot: ti: change keys location