### PR TITLE
u-boot: send hardening warning messages to stderr

### DIFF
--- a/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
@@ -995,21 +995,21 @@ index 00000000000..462df6709d2
 +				    int argc, char *const argv[],
 +				    char *const reason)
 +{
-+	puts("## WARNING: Command execution ");
-+	puts(simulated ? "WOULD BE DENIED in closed state" : "denied");
-+	puts(" (");
-+	puts(reason);
-+	puts(") for `");
++	eputs("## WARNING: Command execution ");
++	eputs(simulated ? "WOULD BE DENIED in closed state" : "denied");
++	eputs(" (");
++	eputs(reason);
++	eputs(") for `");
 +	for (int i = 0; i < argc; i++) {
 +		if (i > 0)
-+			puts(" ");
-+		puts(argv[i]);
++			eputs(" ");
++		eputs(argv[i]);
 +		if (i >= 3) {
-+			puts("...");
++			eputs("...");
 +			break;
 +		}
 +	}
-+	puts("`.\n");
++	eputs("`.\n");
 +}
 +
 +/**

--- a/recipes-bsp/u-boot/files/0007-toradex-add-implementation-of-bootargs-protection.patch
+++ b/recipes-bsp/u-boot/files/0007-toradex-add-implementation-of-bootargs-protection.patch
@@ -151,14 +151,14 @@ index 1134b6ce596..4061bc85eac 100644
 +			}
 +		}
 +		if (bi >= BOOTARG_SPEC_LEN) {
-+			printf("## Unexpected argument in variable bootargs: "
-+			       "%.16s...\n", args);
++			eprintf("## Unexpected argument in variable bootargs: "
++				"%.16s...\n", args);
 +			return 0;
 +		}
 +
 +		if (!_tdx_valid_var_bootarg(value, bootarg_spec[bi].type, &eptr)) {
-+			printf("## Argument validation failed for bootarg "
-+			       "%.16s...\n", args);
++			eprintf("## Argument validation failed for bootarg "
++				"%.16s...\n", args);
 +			return 0;
 +		}
 +
@@ -179,8 +179,8 @@ index 1134b6ce596..4061bc85eac 100644
 +				if (isspace(*reqptr)) conflict = 1;
 +			}
 +			if (conflict) {
-+				printf("## Conflicting argument in variable bootargs: "
-+				       "%.16s...\n", args);
++				eprintf("## Conflicting argument in variable bootargs: "
++					"%.16s...\n", args);
 +				return 0;
 +			}
 +		}
@@ -210,15 +210,15 @@ index 1134b6ce596..4061bc85eac 100644
 +
 +	node_offset = fdt_path_offset(fdt, bootargs_node_path);
 +	if (node_offset < 0) {
-+		printf("## WARNING: Required node \"%s\" could not be found "
-+		       "in device-tree.\n", bootargs_node_path);
++		eprintf("## WARNING: Required node \"%s\" could not be found "
++			"in device-tree.\n", bootargs_node_path);
 +		return 0;
 +	}
 +
 +	req_args = fdt_getprop(fdt, node_offset, req_prop, &req_len);
 +	if (!req_args) {
-+		printf("## WARNING: Required property \"%s/%s\" could not be "
-+		       "found in device-tree.\n", bootargs_node_path, req_prop);
++		eprintf("## WARNING: Required property \"%s/%s\" could not be "
++			"found in device-tree.\n", bootargs_node_path, req_prop);
 +		return 0;
 +	}
 +
@@ -256,19 +256,19 @@ index 1134b6ce596..4061bc85eac 100644
 +	return 1;
 +
 +fixpart_invalid:
-+	printf("## WARNING: Initial part of passed bootargs string (A) does "
-+	       "not match '%s' property (B) in device-tree.\n", req_prop);
-+	printf("##  A: \"%s\"\n", skip_spaces(bootargs));
-+	printf("##  B: \"%.*s\"\n", req_len, req_args);
++	eprintf("## WARNING: Initial part of passed bootargs string (A) does "
++		"not match '%s' property (B) in device-tree.\n", req_prop);
++	eprintf("##  A: \"%s\"\n", skip_spaces(bootargs));
++	eprintf("##  B: \"%.*s\"\n", req_len, req_args);
 +	return 0;
 +
 +varpart_invalid:
-+	printf("## WARNING: Validation of the variable part of bootargs "
-+	       "failed; the full bootargs string (A) and its fixed part "
-+	       "(as defined in the '%s' property inside the device-tree) "
-+	       "follow:\n", req_prop);
-+	printf("##  A: \"%s\"\n", skip_spaces(bootargs));
-+	printf("##  B: \"%.*s\"\n", req_len, req_args);
++	eprintf("## WARNING: Validation of the variable part of bootargs "
++		"failed; the full bootargs string (A) and its fixed part "
++		"(as defined in the '%s' property inside the device-tree) "
++		"follow:\n", req_prop);
++	eprintf("##  A: \"%s\"\n", skip_spaces(bootargs));
++	eprintf("##  B: \"%.*s\"\n", req_len, req_args);
 +	return 0;
 +}
 +#endif

--- a/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-downstream.patch
@@ -60,12 +60,12 @@ index f08915c2c66..5f4f07c8f61 100644
 +		if (tdx_valid_bootargs(fdt, str)) {
 +			printf("## Validation of bootargs succeeded.\n");
 +		} else if (tdx_secboot_dev_is_open()) {
-+			printf("## WARNING: Allowing boot while device is "
-+			       "open; please fix bootargs before closing "
-+			       "device.\n");
++			eprintf("## WARNING: Allowing boot while device is "
++				"open; please fix bootargs before closing "
++				"device.\n");
 +		} else {
-+			printf("## FATAL: Stopping boot process due to "
-+			       "bootargs validation error.\n");
++			eprintf("## FATAL: Stopping boot process due to "
++				"bootargs validation error.\n");
 +			return -FDT_ERR_BADVALUE;
 +		}
 +	}

--- a/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-upstream.patch
@@ -60,12 +60,12 @@ index 8c18af2ce15..c81c2de139c 100644
 +		if (tdx_valid_bootargs(fdt, str)) {
 +			printf("## Validation of bootargs succeeded.\n");
 +		} else if (tdx_secboot_dev_is_open()) {
-+			printf("## WARNING: Allowing boot while device is "
-+			       "open; please fix bootargs before closing "
-+			       "device.\n");
++			eprintf("## WARNING: Allowing boot while device is "
++				"open; please fix bootargs before closing "
++				"device.\n");
 +		} else {
-+			printf("## FATAL: Stopping boot process due to "
-+			       "bootargs validation error.\n");
++			eprintf("## FATAL: Stopping boot process due to "
++				"bootargs validation error.\n");
 +			return -FDT_ERR_BADVALUE;
 +		}
 +	}


### PR DESCRIPTION
Send most of the hardening warning/error messages to U-Boot's stderr to increase the chances they are seen.

Related-to: https://github.com/toradex/meta-toradex-security/issues/64
