### PR TITLE
Fix build issue on imx8 (detected on apalis-imx8 and colibri-imx8x)

### DIFF
--- a/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab.inc
+++ b/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab.inc
@@ -78,7 +78,7 @@ sign_common() {
                     UBOOT_DTB_NAME_EXTRA="${dtb_name}"
                 fi
                 UBOOT_NAME_EXTRA="u-boot-${MACHINE}.bin-${UBOOT_CONFIG_EXTRA}"
-                BOOT_CONFIG_MACHINE_EXTRA="${BOOT_NAME}-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
+                BOOT_CONFIG_MACHINE_EXTRA="imx-boot-${MACHINE}-${UBOOT_CONFIG_EXTRA}.bin"
 
                 # Copy again artifacts for current U-Boot config to BOOT_STAGING
                 compile_${SOC_FAMILY}


### PR DESCRIPTION
Upstream project meta-freescale has dropped variable BOOT_NAME since c30f12b8 (imx-boot: Drop un-necessary variable BOOT_NAME) which was actually used by this layer to determine the name of the bootloader binary to be signed. Here we follow along by hard-coding the value that was previously in that variable.

See https://github.com/Freescale/meta-freescale/commit/c30f12b809a8cf36043b42c67dd8a11f69d9cf77