### PR TITLE
Adapt hardening to AM62 (scarthgap)

### DIFF
--- a/classes/tdx-signed-fit-image.inc
+++ b/classes/tdx-signed-fit-image.inc
@@ -17,6 +17,7 @@ FIT_KEY_REQ_ARGS ?= "-batch -new"
 FIT_KEY_SIGN_PKCS ?= "-x509"
 
 # parameters to sign FIT images
+FIT_HASH_ALG ?= "sha256"
 FIT_SIGN_ALG ?= "rsa2048"
 FIT_SIGN_NUMBITS ?= "2048"
 FIT_SIGN_INDIVIDUAL = "0"

--- a/classes/tdx-signed-fit-image.inc
+++ b/classes/tdx-signed-fit-image.inc
@@ -21,3 +21,14 @@ FIT_HASH_ALG ?= "sha256"
 FIT_SIGN_ALG ?= "rsa2048"
 FIT_SIGN_NUMBITS ?= "2048"
 FIT_SIGN_INDIVIDUAL = "0"
+
+# stronger assignments to override settings in meta-ti
+#
+# NOTICE: a side effect of these assignments is that users will need to use
+#         :forcevariable (or an override stronger than :k3) to set them.
+UBOOT_SIGN_KEYDIR:k3 ?= "${TOPDIR}/keys/fit"
+UBOOT_SIGN_KEYNAME:k3 ?= "dev"
+UBOOT_SIGN_IMG_KEYNAME:k3 ?= "dev2"
+FIT_HASH_ALG:k3 ?= "sha256"
+FIT_SIGN_ALG:k3 ?= "rsa2048"
+FIT_SIGN_NUMBITS:k3 ?= "2048"

--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -40,6 +40,7 @@ TDX_SECBOOT_REQUIRED_BOOTARGS:apalis-imx8 ?= "ro rootwait console=tty1 console=t
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mm ?= "ro rootwait console=tty1 console=ttymxc0,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mp ?= "ro rootwait console=tty1 console=ttymxc2,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx8x ?= "ro rootwait console=tty1 console=ttyLP3,115200"
+TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-am62 ?= "ro rootwait console=tty1 console=ttyS2,115200"
 
 # Name of the overlay file (without extension) that will contain the fixed part
 # of the kernel command line; this will be stored inside the FIT image; notice

--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -1,8 +1,8 @@
 # Enable the Secure Boot hardening of U-Boot by Toradex.
 #
-# Currently the hardening implementation requires HAB/AHAB to be enabled so that
-# the combination TDX_IMX_HAB_ENABLE="0" TDX_UBOOT_HARDENING_ENABLE="1" is not
-# valid.
+# Currently the hardening implementation requires HAB/AHAB (or equivalent
+# technology in TI SoCs) to be enabled so that the combination
+# TDX_IMX_HAB_ENABLE="0" and TDX_UBOOT_HARDENING_ENABLE="1" is not valid.
 #
 # Also the hardening itself is supposed to protect the second link of the chain
 # of trust i.e. the link between bootloader and the kernel artifacts. So, the
@@ -13,12 +13,18 @@
 # UBOOT_SIGN_ENABLE are set, by default.
 #
 def default_tdx_uboot_hardening_enable(d):
-    if (bb.utils.to_boolean(d.getVar('TDX_IMX_HAB_ENABLE')) and
+    if ('imx-generic-bsp' in d.getVar('OVERRIDES').split(':') and
+        bb.utils.to_boolean(d.getVar('TDX_IMX_HAB_ENABLE')) and
+        bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE'))):
+        return True
+    if ('k3' in d.getVar('OVERRIDES').split(':') and
+        bb.utils.to_boolean(d.getVar('TDX_K3_HSSE_ENABLE')) and
         bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE'))):
         return True
     return False
 
 TDX_UBOOT_HARDENING_ENABLE ?= "${@'1' if default_tdx_uboot_hardening_enable(d) else '0'}"
+TDX_UBOOT_HARDENING_ENABLE:verdin-am62-k3r5 = "0"
 
 # Configure the "kernel command-line protection"; with this protection, the
 # fixed part of the bootargs are saved into the FIT image and checked against

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -113,6 +113,10 @@ A few variables can be used to configure this feature, including:
 
 The complete list of variables can be found in the `tdx-signed-fit-image.inc` file.
 
+### Configuring FIT image signing / known issues
+
+- On the **Verdin AM62** SoM, some of the configuration variables (e.g. `UBOOT_SIGN_KEYDIR`, `UBOOT_SIGN_KEYNAME` (check the complete list in `tdx-signed-fit-image.inc`)) are set through override `k3` to ensure the values coming from layer `meta-toradex-security` override those from layer `meta-ti-bsp`. Due to this, the recommended way to set those variables is via override `forcevariable`.
+
 ## Configuring rootfs image signing
 
 When the `tdxref-signed` class is inherited, the rootfs image will be generated using the `dm-verity` kernel feature.

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -65,9 +65,11 @@ The hardening features above are controlled by the following variables:
 
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
-| `TDX_UBOOT_HARDENING_ENABLE` | Enable hardening features as a whole | `1` if both `TDX_IMX_HAB_ENABLE` and `UBOOT_SIGN_ENABLE` are set; `0` otherwise |
+| `TDX_UBOOT_HARDENING_ENABLE` | Enable hardening features as a whole | `1` if both secure boot support (controlled by variable `TDX_IMX_HAB_ENABLE` (NXP) or `TDX_K3_HSSE_ENABLE` (TI)) and FIT signing (controlled by `UBOOT_SIGN_ENABLE`) are enabled; `0` otherwise |
 | `TDX_SECBOOT_REQUIRED_BOOTARGS` | Expected value for the fixed part of the kernel command line | Different value for each machine |
 | `TDX_AMEND_BOOT_SCRIPT` | When set to `1` the boot script will be amended to make it suitable for secure boot; this only works with the script provided by Toradex for BSP reference images; users employing a custom script should set this to `0` | Same value as variable `TDX_UBOOT_HARDENING_ENABLE` |
+
+### U-Boot hardening / setup
 
 The behavior of the different hardening features can be set via the control FDT (see [Devicetree Control in U-Boot](https://u-boot.readthedocs.io/en/stable/develop/devicetree/control.html)). Setting the control FDT at build time can be achieved by adding extra device-tree [.dtsi fragments](https://u-boot.readthedocs.io/en/stable/develop/devicetree/control.html#external-dtsi-fragments) to U-Boot and setting the Kconfig variable `CONFIG_DEVICE_TREE_INCLUDES` appropriately; with Yocto/OE this would normally involve adding small patches to U-Boot and appending changes to its recipe but the details are outside the scope of the present document.
 
@@ -94,6 +96,10 @@ The following device-tree fragment shows all the nodes and properties that can b
 The command categories are currently only available as part of a [patch](./recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch) in header `cmd-categories.h`. The default FDT is part of another [patch](./recipes-bsp/u-boot/files/0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch) in file `tdx-secboot.dtsi`.
 
 <!-- TODO: Make more user-friendly instructions on setting the control FDT. -->
+
+### U-Boot hardening / known issues
+
+- On the **Verdin AM62** SoM, the hardening does not cover the bootloader running on the R5 processor (the boot master); we have plans to evaluate the need for such a protection and implementing it if actually needed.
 
 ## Configuring FIT image signing
 
@@ -136,7 +142,3 @@ When `tdxref-signed` is used to enable secure boot, the rootfs image is generate
 Because `dm-verity` is read-only, you might want to create an additional partition in the eMMC to store persistent data.
 
 If that is the case, you can use the `tdx-tezi-data-partition` class. For more information, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).
-
-## Known issues and limitations
-
-- Currently the hardening is implemented/integrated on NXP SoCs only; when building for other SoC vendors one has to disable the feature (set `TDX_UBOOT_HARDENING_ENABLE=` to `0`) or the build will fail.

--- a/dynamic-layers/toradex-nxp/recipes-kernel/linux/device-tree-overlays-ti_%.bbappend
+++ b/dynamic-layers/toradex-nxp/recipes-kernel/linux/device-tree-overlays-ti_%.bbappend
@@ -1,0 +1,1 @@
+require ${@ 'recipes-kernel/linux/add-secboot-kargs-overlay.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}

--- a/recipes-bsp/u-boot/files/0001-toradex-add-helper-to-detect-closed-k3-based-device-.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-add-helper-to-detect-closed-k3-based-device-.patch
@@ -1,0 +1,35 @@
+From 0e0e5a4aa02db9d5246682c534eac25a034c922b Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Wed, 9 Oct 2024 20:23:16 -0300
+Subject: [PATCH 1/2] toradex: add helper to detect closed k3-based device
+ (am62)
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ arch/arm/mach-k3/common.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm/mach-k3/common.c b/arch/arm/mach-k3/common.c
+index 3e2e2f4397b..c0bbc7896f6 100644
+--- a/arch/arm/mach-k3/common.c
++++ b/arch/arm/mach-k3/common.c
+@@ -495,6 +495,14 @@ static const char *get_device_type_name(void)
+ 	}
+ }
+ 
++#if defined(CONFIG_TDX_SECBOOT_HARDENING)
++int tdx_secboot_k3_dev_is_closed(void)
++{
++	/* Device is closed (security enforced (SE) state). */
++	return (get_device_type() == K3_DEVICE_TYPE_HS_SE);
++}
++#endif
++
+ int print_cpuinfo(void)
+ {
+ 	struct udevice *soc;
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
@@ -1,7 +1,7 @@
-From 70b7241992acd4e9d9c002f6f473b486d18a7f02 Mon Sep 17 00:00:00 2001
+From e48ddc42aa67f8353d3cd8571a4360c5741e20b3 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:28:50 -0300
-Subject: [PATCH 1/7] toradex: common: add command whitelisting modules
+Subject: [PATCH 1/9] toradex: common: add command whitelisting modules
 
 Add modules implementing the command whitelisting feature to be
 integrated into U-Boot on a separate commit.
@@ -22,7 +22,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 
 diff --git a/common/tdx-harden.c b/common/tdx-harden.c
 new file mode 100644
-index 0000000000..789d1ed128
+index 00000000000..789d1ed1285
 --- /dev/null
 +++ b/common/tdx-harden.c
 @@ -0,0 +1,260 @@
@@ -288,7 +288,7 @@ index 0000000000..789d1ed128
 +#endif
 diff --git a/common/whitelist.c b/common/whitelist.c
 new file mode 100644
-index 0000000000..462df6709d
+index 00000000000..ac460202124
 --- /dev/null
 +++ b/common/whitelist.c
 @@ -0,0 +1,841 @@
@@ -1135,7 +1135,7 @@ index 0000000000..462df6709d
 +}
 diff --git a/include/dt-bindings/secure-boot/cmd-categories.h b/include/dt-bindings/secure-boot/cmd-categories.h
 new file mode 100644
-index 0000000000..002f118499
+index 00000000000..002f118499e
 --- /dev/null
 +++ b/include/dt-bindings/secure-boot/cmd-categories.h
 @@ -0,0 +1,101 @@
@@ -1242,7 +1242,7 @@ index 0000000000..002f118499
 +#endif
 diff --git a/include/tdx-harden.h b/include/tdx-harden.h
 new file mode 100644
-index 0000000000..dfdaa69d3a
+index 00000000000..dfdaa69d3a4
 --- /dev/null
 +++ b/include/tdx-harden.h
 @@ -0,0 +1,42 @@

--- a/recipes-bsp/u-boot/files/0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch
+++ b/recipes-bsp/u-boot/files/0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch
@@ -1,7 +1,7 @@
-From 83b2a8eabdd54f20d902ad2eb6032e98680ac1cb Mon Sep 17 00:00:00 2001
+From 52726ca939d29f7700cae6b94902b4b6153b42e7 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Tue, 22 Aug 2023 22:56:24 -0300
-Subject: [PATCH 2/7] toradex: dts: add fragment file to configure secure boot
+Subject: [PATCH 2/9] toradex: dts: add fragment file to configure secure boot
 
 Add to the source tree the file 'tdx-secboot.dtsi' having the default
 configuration for the Toradex "Secure Boot"-related features. If built

--- a/recipes-bsp/u-boot/files/0002-toradex-support-detecting-closed-k3-based-device-am6.patch
+++ b/recipes-bsp/u-boot/files/0002-toradex-support-detecting-closed-k3-based-device-am6.patch
@@ -1,0 +1,31 @@
+From 641eac2471cb64da9a2b22b2ebc42dbdd1183740 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Wed, 9 Oct 2024 20:28:32 -0300
+Subject: [PATCH 2/2] toradex: support detecting closed k3-based device (am62)
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/tdx-harden.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/common/tdx-harden.c b/common/tdx-harden.c
+index a8f303aaf63..f992b0cab76 100644
+--- a/common/tdx-harden.c
++++ b/common/tdx-harden.c
+@@ -144,6 +144,11 @@ static int _tdx_secboot_dev_is_open(void)
+ 	default:	/* Unknown */
+ 		break;
+ 	}
++#elif defined(CONFIG_ARCH_K3)
++	int tdx_secboot_k3_dev_is_closed(void);
++	if (tdx_secboot_k3_dev_is_closed()) {
++		return 0;
++	}
+ #else
+ #error Neither CONFIG_IMX_HAB nor CONFIG_AHAB_BOOT is set
+ #endif
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-downstream.patch
+++ b/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-downstream.patch
@@ -1,7 +1,7 @@
-From 64bb5b975a890f13455757183d4084f375216697 Mon Sep 17 00:00:00 2001
+From e3cf5272047a931ee83148682d5da0164031eff8 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:29:34 -0300
-Subject: [PATCH 3/7] toradex: integrate command whitelisting (downstream)
+Subject: [PATCH 3/9] toradex: integrate command whitelisting (downstream)
 
 Integrate the command whitelisting feature which is part of the Secure
 Boot hardening on U-Boot made by Toradex. The feature allows categories
@@ -20,7 +20,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  3 files changed, 35 insertions(+)
 
 diff --git a/Kconfig b/Kconfig
-index 0b00696198a..badab0318d6 100644
+index 5710934000f..5f6ec0afbbf 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -742,3 +742,31 @@ source "lib/Kconfig"
@@ -56,7 +56,7 @@ index 0b00696198a..badab0318d6 100644
 +	help
 +	  Enable the command white-listing feature provided by Toradex.
 diff --git a/common/Makefile b/common/Makefile
-index a83dcbee81e..8317e002ff0 100644
+index 009e0da8a40..a2d89720674 100644
 --- a/common/Makefile
 +++ b/common/Makefile
 @@ -24,6 +24,8 @@ obj-$(CONFIG_DISPLAY_BOARDINFO_LATE) += board_info.o

--- a/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-upstream.patch
+++ b/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-upstream.patch
@@ -1,7 +1,7 @@
-From c230f3e4e8e4dfe3b7fb21e9aaada4685e9f521d Mon Sep 17 00:00:00 2001
+From 15f079851e0ce53edb5b531f24276ad6cc8537e6 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:29:34 -0300
-Subject: [PATCH 3/7] toradex: integrate command whitelisting (upstream)
+Subject: [PATCH 3/9] toradex: integrate command whitelisting (upstream)
 
 Integrate the command whitelisting feature which is part of the Secure
 Boot hardening on U-Boot made by Toradex. The feature allows categories
@@ -20,7 +20,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  3 files changed, 35 insertions(+)
 
 diff --git a/Kconfig b/Kconfig
-index 82df59f176..62d66b831a 100644
+index 82df59f176e..62d66b831af 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -756,3 +756,31 @@ source "lib/Kconfig"
@@ -56,7 +56,7 @@ index 82df59f176..62d66b831a 100644
 +	help
 +	  Enable the command white-listing feature provided by Toradex.
 diff --git a/common/Makefile b/common/Makefile
-index e983547342..1980fead6b 100644
+index e9835473420..1980fead6bd 100644
 --- a/common/Makefile
 +++ b/common/Makefile
 @@ -24,6 +24,8 @@ obj-$(CONFIG_DISPLAY_BOARDINFO_LATE) += board_info.o
@@ -69,7 +69,7 @@ index e983547342..1980fead6b 100644
  obj-$(CONFIG_USB_HOST) += usb.o usb_hub.o
  obj-$(CONFIG_USB_GADGET) += usb.o
 diff --git a/common/command.c b/common/command.c
-index af8ffdba8f..7268bfd9e7 100644
+index af8ffdba8f8..7268bfd9e7d 100644
 --- a/common/command.c
 +++ b/common/command.c
 @@ -18,6 +18,7 @@

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-downstream.patch
@@ -1,7 +1,7 @@
-From bf3a1480df354b3cdd71ff1f2491bdac97a9496c Mon Sep 17 00:00:00 2001
+From 53d1e88ef7dd7761bfe38d48daca4045a99d53a3 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 26 Jun 2024 16:08:52 -0300
-Subject: [PATCH 4/7] toradex: integrate bootm protection (downstream)
+Subject: [PATCH 4/9] toradex: integrate bootm protection (downstream)
 
 Integrate the protection to the bootm command to only allow booting
 from FIT images. With the proper configuration of U-Boot (enabling FIT
@@ -17,7 +17,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  2 files changed, 70 insertions(+), 1 deletion(-)
 
 diff --git a/Kconfig b/Kconfig
-index badab0318d6..258de43d449 100644
+index 5f6ec0afbbf..73a0dd8cfd8 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -746,6 +746,7 @@ source "tools/Kconfig"

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-upstream.patch
@@ -1,7 +1,7 @@
-From 5a9ab2d881076afb5d8b05145068d3a889301b8f Mon Sep 17 00:00:00 2001
+From 9a380ee7ace8af5800f240557a55352e8a37a9d4 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 26 Jun 2024 16:08:52 -0300
-Subject: [PATCH 4/7] toradex: integrate bootm protection (upstream)
+Subject: [PATCH 4/9] toradex: integrate bootm protection (upstream)
 
 Integrate the protection to the bootm command to only allow booting
 from FIT images. With the proper configuration of U-Boot (enabling FIT
@@ -17,7 +17,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  2 files changed, 70 insertions(+), 1 deletion(-)
 
 diff --git a/Kconfig b/Kconfig
-index 62d66b831a..f046c21cc7 100644
+index 62d66b831af..f046c21cc7e 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -760,6 +760,7 @@ source "tools/Kconfig"
@@ -39,7 +39,7 @@ index 62d66b831a..f046c21cc7 100644
 +	  Enable the protection in bootm to prevent execution of unsigned
 +	  images.
 diff --git a/boot/bootm.c b/boot/bootm.c
-index 9879e1bba4..b39c53ab9d 100644
+index 9879e1bba4e..b39c53ab9d1 100644
 --- a/boot/bootm.c
 +++ b/boot/bootm.c
 @@ -34,6 +34,7 @@

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-downstream.patch
@@ -1,7 +1,7 @@
-From d170e739114d0349b35fb59a3f61e1b243ebb6bb Mon Sep 17 00:00:00 2001
+From 71b8647ae21b12e42b1848bed3ecacf43deeb941 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 13 Sep 2023 15:22:25 -0300
-Subject: [PATCH 5/7] toradex: integrate CLI access protection (downstream)
+Subject: [PATCH 5/9] toradex: integrate CLI access protection (downstream)
 
 Integrate the protection in U-Boot to prevent access to its CLI once
 the device is closed; this is part of the hardening for Secure Boot.
@@ -17,7 +17,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  4 files changed, 71 insertions(+), 1 deletion(-)
 
 diff --git a/Kconfig b/Kconfig
-index 258de43d449..f8df1a262a1 100644
+index 73a0dd8cfd8..d39a38879cc 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -747,6 +747,7 @@ config TDX_SECBOOT_HARDENING

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-upstream.patch
@@ -1,7 +1,7 @@
-From 77b9e5a11a2544622985ebb82152041b9d664d77 Mon Sep 17 00:00:00 2001
+From 8f5d953a2615627e1f8d2bac55f9b9204bba4ff7 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 13 Sep 2023 15:22:25 -0300
-Subject: [PATCH 5/7] toradex: integrate CLI access protection (upstream)
+Subject: [PATCH 5/9] toradex: integrate CLI access protection (upstream)
 
 Integrate the protection in U-Boot to prevent access to its CLI once
 the device is closed; this is part of the hardening for Secure Boot.
@@ -17,7 +17,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  4 files changed, 71 insertions(+), 1 deletion(-)
 
 diff --git a/Kconfig b/Kconfig
-index f046c21cc7..59591a7a52 100644
+index f046c21cc7e..59591a7a523 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -761,6 +761,7 @@ config TDX_SECBOOT_HARDENING
@@ -39,7 +39,7 @@ index f046c21cc7..59591a7a52 100644
 +	  Enable the protection where the CLI is disabled when the device
 +	  is in closed state.
 diff --git a/common/main.c b/common/main.c
-index 82d3aafa53..13db55df88 100644
+index 82d3aafa53c..13db55df889 100644
 --- a/common/main.c
 +++ b/common/main.c
 @@ -20,6 +20,7 @@
@@ -62,7 +62,7 @@ index 82d3aafa53..13db55df88 100644
  		cli_secure_boot_cmd(s);
  
 diff --git a/common/tdx-harden.c b/common/tdx-harden.c
-index fb8aaa5eed..1134b6ce59 100644
+index 789d1ed1285..dbdb8c5e337 100644
 --- a/common/tdx-harden.c
 +++ b/common/tdx-harden.c
 @@ -6,6 +6,7 @@
@@ -139,7 +139,7 @@ index fb8aaa5eed..1134b6ce59 100644
 +#error Toradex hardening assumes CONFIG_UPDATE_TFTP is not set
 +#endif
 diff --git a/include/tdx-harden.h b/include/tdx-harden.h
-index dfdaa69d3a..50e850ba2a 100644
+index dfdaa69d3a4..50e850ba2af 100644
 --- a/include/tdx-harden.h
 +++ b/include/tdx-harden.h
 @@ -12,6 +12,8 @@

--- a/recipes-bsp/u-boot/files/0006-toradex-add-implementation-of-bootargs-protection.patch
+++ b/recipes-bsp/u-boot/files/0006-toradex-add-implementation-of-bootargs-protection.patch
@@ -1,7 +1,7 @@
-From c46e13ec0569059ea79ded8fc2823624444fb9a2 Mon Sep 17 00:00:00 2001
+From 79fed2d4d0629c90fa7d541399fb33316457d85d Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 6 Nov 2023 22:25:28 -0300
-Subject: [PATCH 6/7] toradex: add implementation of bootargs protection
+Subject: [PATCH 6/9] toradex: add implementation of bootargs protection
 
 This only adds the code implementing the feature but does not integrate
 it into U-Boot.
@@ -15,7 +15,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  2 files changed, 238 insertions(+), 2 deletions(-)
 
 diff --git a/common/tdx-harden.c b/common/tdx-harden.c
-index dbdb8c5e33..f1f111dfc0 100644
+index dbdb8c5e337..2a2a775ffec 100644
 --- a/common/tdx-harden.c
 +++ b/common/tdx-harden.c
 @@ -3,12 +3,18 @@
@@ -277,7 +277,7 @@ index dbdb8c5e33..f1f111dfc0 100644
  {
  	int hdn_enabled = tdx_hardening_enabled();
 diff --git a/include/tdx-harden.h b/include/tdx-harden.h
-index 50e850ba2a..1cb61aed45 100644
+index 50e850ba2af..1cb61aed45e 100644
 --- a/include/tdx-harden.h
 +++ b/include/tdx-harden.h
 @@ -26,14 +26,18 @@

--- a/recipes-bsp/u-boot/files/0007-toradex-integrate-bootargs-protection-am62.patch
+++ b/recipes-bsp/u-boot/files/0007-toradex-integrate-bootargs-protection-am62.patch
@@ -1,7 +1,7 @@
 From 8d73f47e7b6a0ea580e99bc6da5b52af32f064f9 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 26 Oct 2023 12:40:46 -0300
-Subject: [PATCH 7/7] toradex: integrate bootargs protection (am62)
+Subject: [PATCH 7/9] toradex: integrate bootargs protection (am62)
 
 Upstream-Status: Inappropriate [TorizonCore specific]
 

--- a/recipes-bsp/u-boot/files/0007-toradex-integrate-bootargs-protection-am62.patch
+++ b/recipes-bsp/u-boot/files/0007-toradex-integrate-bootargs-protection-am62.patch
@@ -1,0 +1,79 @@
+From 8d73f47e7b6a0ea580e99bc6da5b52af32f064f9 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 26 Oct 2023 12:40:46 -0300
+Subject: [PATCH 7/7] toradex: integrate bootargs protection (am62)
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ Kconfig            | 10 ++++++++++
+ boot/fdt_support.c | 20 ++++++++++++++++++++
+ 2 files changed, 30 insertions(+)
+
+diff --git a/Kconfig b/Kconfig
+index d39a38879cc..841db6cdf1b 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -748,6 +748,7 @@ config TDX_SECBOOT_HARDENING
+ 	select TDX_CMD_WHITELIST
+ 	select TDX_BOOTM_PROTECTION
+ 	select TDX_CLI_PROTECTION
++	select TDX_BOOTARGS_PROTECTION
+ 	help
+ 	  This causes the Secure Boot hardening features added by Toradex
+ 	  to be built into U-Boot, including:
+@@ -784,3 +785,12 @@ config TDX_CLI_PROTECTION
+ 	help
+ 	  Enable the protection where the CLI is disabled when the device
+ 	  is in closed state.
++
++config TDX_BOOTARGS_PROTECTION
++	bool
++	help
++	  Enable the protection for the kernel command line (bootargs); with
++	  this feature, U-Boot will check the "bootargs" environment variable
++	  against information in the device-tree provided to the bootm
++	  command. Since the device-tree is supposed to come from a signed
++	  FIT image, it is expected to be a trustworthy source of information.
+diff --git a/boot/fdt_support.c b/boot/fdt_support.c
+index fd20870a320..48231f80d14 100644
+--- a/boot/fdt_support.c
++++ b/boot/fdt_support.c
+@@ -26,6 +26,10 @@
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
++#ifdef CONFIG_TDX_BOOTARGS_PROTECTION
++#include <tdx-harden.h>
++#endif
++
+ /**
+  * fdt_getprop_u32_default_node - Return a node's property or a default
+  *
+@@ -313,6 +317,22 @@ int fdt_chosen(void *fdt)
+ 
+ 	str = board_fdt_chosen_bootargs();
+ 
++#ifdef CONFIG_TDX_BOOTARGS_PROTECTION
++	if (tdx_hardening_enabled()) {
++		if (tdx_valid_bootargs(fdt, str)) {
++			printf("## Validation of bootargs succeeded.\n");
++		} else if (tdx_secboot_dev_is_open()) {
++			eprintf("## WARNING: Allowing boot while device is "
++				"open; please fix bootargs before closing "
++				"device.\n");
++		} else {
++			eprintf("## FATAL: Stopping boot process due to "
++				"bootargs validation error.\n");
++			return -FDT_ERR_BADVALUE;
++		}
++	}
++#endif
++
+ 	if (str) {
+ 		err = fdt_setprop(fdt, nodeoffset, "bootargs", str,
+ 				  strlen(str) + 1);
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0007-toradex-integrate-bootargs-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0007-toradex-integrate-bootargs-protection-upstream.patch
@@ -1,7 +1,7 @@
-From d9c08b2ffe922bd50b5007765059f1690f9013ef Mon Sep 17 00:00:00 2001
+From 5cabfcf4945aabbdee876597440366112876d43e Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 26 Oct 2023 12:40:46 -0300
-Subject: [PATCH 7/7] toradex: integrate bootargs protection (upstream)
+Subject: [PATCH 7/9] toradex: integrate bootargs protection (upstream)
 
 Upstream-Status: Inappropriate [TorizonCore specific]
 
@@ -12,7 +12,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  2 files changed, 30 insertions(+)
 
 diff --git a/Kconfig b/Kconfig
-index 59591a7a52..4a4b100568 100644
+index 59591a7a523..4a4b1005688 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -762,6 +762,7 @@ config TDX_SECBOOT_HARDENING
@@ -37,7 +37,7 @@ index 59591a7a52..4a4b100568 100644
 +	  command. Since the device-tree is supposed to come from a signed
 +	  FIT image, it is expected to be a trustworthy source of information.
 diff --git a/boot/fdt_support.c b/boot/fdt_support.c
-index 2bd80a9dfb..717709e059 100644
+index 2bd80a9dfb1..e27f6f88300 100644
 --- a/boot/fdt_support.c
 +++ b/boot/fdt_support.c
 @@ -27,6 +27,10 @@

--- a/recipes-bsp/u-boot/files/0008-toradex-show-message-if-CLI-access-allowed-common.patch
+++ b/recipes-bsp/u-boot/files/0008-toradex-show-message-if-CLI-access-allowed-common.patch
@@ -1,0 +1,82 @@
+From 4157359194e1243f9fc7136f3022ac3b2a8e0d24 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 10 Oct 2024 00:38:50 -0300
+Subject: [PATCH 8/9] toradex: show message if CLI access allowed (common)
+
+Before, a message was shown only when the device was closed and the CLI
+access was disabled by the CLI protection feature. Now we show a message
+also when the device is open which is helpful when someone wants to
+ensure the protection is compiled in without having to close the device.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/tdx-harden.c  | 25 ++++++++++++++++++++-----
+ include/tdx-harden.h |  2 +-
+ 2 files changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/common/tdx-harden.c b/common/tdx-harden.c
+index 2a2a775ffec..30cf559067c 100644
+--- a/common/tdx-harden.c
++++ b/common/tdx-harden.c
+@@ -199,10 +199,9 @@ int tdx_secboot_dev_is_open(void)
+ 
+ #ifdef CONFIG_TDX_CLI_PROTECTION
+ /**
+- * tdx_cli_access_enabled - Determine if U-Boot CLI access is to be enabled
+- * Return: 1 if CLI access is to be enabled or 0 otherwise.
++ * TODO: Return status instead and show more detailed info in tdx_cli_access_enabled().
+  */
+-int tdx_cli_access_enabled(void)
++static int _tdx_cli_access_enabled(void)
+ {
+ 	const void *en_prop;
+ 	int secboot_offset, prop_len;
+@@ -232,12 +231,28 @@ int tdx_cli_access_enabled(void)
+ 	return 0;
+ }
+ 
++/**
++ * tdx_cli_access_enabled - Determine if U-Boot CLI access is to be enabled
++ * Return: 1 if CLI access is to be enabled or 0 otherwise.
++ */
++int tdx_cli_access_enabled(int showmsg)
++{
++	int res = _tdx_cli_access_enabled();
++	if (!showmsg)
++		return res;
++
++	if (res)
++		printf("## U-Boot CLI access is enabled\n");
++	else
++		printf("## U-Boot CLI access is disabled due to Secure Boot\n");
++
++	return res;
++}
++
+ void tdx_secure_boot_cmd(const char *cmd)
+ {
+ 	int rc;
+ 
+-	printf("## U-Boot CLI access is disabled due to Secure Boot\n");
+-
+ 	disable_ctrlc(1);
+ 	rc = run_command_list(cmd, -1, 0);
+ 
+diff --git a/include/tdx-harden.h b/include/tdx-harden.h
+index 1cb61aed45e..2209780b4c5 100644
+--- a/include/tdx-harden.h
++++ b/include/tdx-harden.h
+@@ -43,7 +43,7 @@ struct cmd_tbl;
+ int cmd_allowed_by_whitelist(struct cmd_tbl *cmd, int argc, char *const argv[]);
+ int tdx_secboot_dev_is_open(void);
+ int tdx_hardening_enabled(void);
+-int tdx_cli_access_enabled(void);
++int tdx_cli_access_enabled(int showmsg);
+ void tdx_secure_boot_cmd(const char *cmd);
+ int tdx_valid_bootargs(void *fdt, const char *bootargs);
+ 
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0009-toradex-show-message-if-CLI-access-allowed-downstrea.patch
+++ b/recipes-bsp/u-boot/files/0009-toradex-show-message-if-CLI-access-allowed-downstrea.patch
@@ -1,0 +1,33 @@
+From b3c3e36623d0e26fcc0d4d25ae5d2bfd375b1f5b Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 10 Oct 2024 00:39:52 -0300
+Subject: [PATCH 9/9] toradex: show message if CLI access allowed (downstream)
+
+Before, a message was shown only when the device was closed and the CLI
+access was disabled by the CLI protection feature. Now we show a message
+also when the device is open which is helpful when someone wants to
+ensure the protection is compiled in without having to close the device.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/main.c b/common/main.c
+index 1284ecbd8c9..ce779345d67 100644
+--- a/common/main.c
++++ b/common/main.c
+@@ -68,7 +68,7 @@ void main_loop(void)
+ 
+ 	s = bootdelay_process();
+ #if CONFIG_IS_ENABLED(TDX_CLI_PROTECTION)
+-	if (!tdx_cli_access_enabled())
++	if (!tdx_cli_access_enabled(1))
+ 		tdx_secure_boot_cmd(s); 	/* no return */
+ #endif
+ 	if (cli_process_fdt(&s))
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0009-toradex-show-message-if-CLI-access-allowed-upstream.patch
+++ b/recipes-bsp/u-boot/files/0009-toradex-show-message-if-CLI-access-allowed-upstream.patch
@@ -1,0 +1,35 @@
+From 35541158e41a5a9f649b07af284efa91fb6a9bc3 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 10 Oct 2024 00:39:52 -0300
+Subject: [PATCH 9/9] toradex: show message if CLI access allowed (upstream)
+
+Before, a message was shown only when the device was closed and the CLI
+access was disabled by the CLI protection feature. Now we show a message
+also when the device is open which is helpful when someone wants to
+ensure the protection is compiled in without having to close the device.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/main.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/common/main.c b/common/main.c
+index 13db55df889..ce779345d67 100644
+--- a/common/main.c
++++ b/common/main.c
+@@ -68,8 +68,8 @@ void main_loop(void)
+ 
+ 	s = bootdelay_process();
+ #if CONFIG_IS_ENABLED(TDX_CLI_PROTECTION)
+-	if (!tdx_cli_access_enabled())
+-		tdx_secure_boot_cmd(s);		/* no return */
++	if (!tdx_cli_access_enabled(1))
++		tdx_secure_boot_cmd(s); 	/* no return */
+ #endif
+ 	if (cli_process_fdt(&s))
+ 		cli_secure_boot_cmd(s);
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -6,6 +6,8 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM = "\
     file://0005-toradex-integrate-CLI-access-protection-downstream.patch \
     file://0006-toradex-add-implementation-of-bootargs-protection.patch \
     file://0007-toradex-integrate-bootargs-protection-downstream.patch \
+    file://0008-toradex-show-message-if-CLI-access-allowed-common.patch \
+    file://0009-toradex-show-message-if-CLI-access-allowed-downstrea.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
@@ -16,6 +18,8 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
     file://0005-toradex-integrate-CLI-access-protection-downstream.patch \
     file://0006-toradex-add-implementation-of-bootargs-protection.patch \
     file://0007-toradex-integrate-bootargs-protection-am62.patch \
+    file://0008-toradex-show-message-if-CLI-access-allowed-common.patch \
+    file://0009-toradex-show-message-if-CLI-access-allowed-downstrea.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
@@ -26,6 +30,8 @@ TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
     file://0005-toradex-integrate-CLI-access-protection-upstream.patch \
     file://0006-toradex-add-implementation-of-bootargs-protection.patch \
     file://0007-toradex-integrate-bootargs-protection-upstream.patch \
+    file://0008-toradex-show-message-if-CLI-access-allowed-common.patch \
+    file://0009-toradex-show-message-if-CLI-access-allowed-upstream.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES = "${TDX_UBOOT_HARDENING_PATCHES_UPSTREAM}"

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -20,6 +20,9 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
     file://0007-toradex-integrate-bootargs-protection-am62.patch \
     file://0008-toradex-show-message-if-CLI-access-allowed-common.patch \
     file://0009-toradex-show-message-if-CLI-access-allowed-downstrea.patch \
+    \
+    file://0001-toradex-add-helper-to-detect-closed-k3-based-device-.patch \
+    file://0002-toradex-support-detecting-closed-k3-based-device-am6.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -8,6 +8,16 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM = "\
     file://0007-toradex-integrate-bootargs-protection-downstream.patch \
 "
 
+TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
+    file://0001-toradex-common-add-command-whitelisting-modules.patch \
+    file://0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch \
+    file://0003-toradex-integrate-command-whitelisting-downstream.patch \
+    file://0004-toradex-integrate-bootm-protection-downstream.patch \
+    file://0005-toradex-integrate-CLI-access-protection-downstream.patch \
+    file://0006-toradex-add-implementation-of-bootargs-protection.patch \
+    file://0007-toradex-integrate-bootargs-protection-am62.patch \
+"
+
 TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
     file://0001-toradex-common-add-command-whitelisting-modules.patch \
     file://0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch \
@@ -21,6 +31,8 @@ TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
 TDX_UBOOT_HARDENING_PATCHES = "${TDX_UBOOT_HARDENING_PATCHES_UPSTREAM}"
 TDX_UBOOT_HARDENING_PATCHES:apalis-imx8 = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM}"
 TDX_UBOOT_HARDENING_PATCHES:colibri-imx8x = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM}"
+TDX_UBOOT_HARDENING_PATCHES:verdin-am62 = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62}"
+TDX_UBOOT_HARDENING_PATCHES:verdin-am62-k3r5 = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62}"
 
 SRC_URI:append = "\
     file://u-boot-harden.cfg \

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -39,8 +39,24 @@ SRC_URI:append = "\
     ${TDX_UBOOT_HARDENING_PATCHES} \
 "
 
-do_compile:prepend() {
+do_compile:prepend:imx-generic-bsp() {
     if [ "${TDX_IMX_HAB_ENABLE}" = "0" ] && [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
-        bbfatal 'The combination TDX_IMX_HAB_ENABLE = "0" and TDX_UBOOT_HARDENING_ENABLE = "1" is not allowed: the whitelisting feature (part of the hardening) currently relies on HAB/AHAB.'
+        bbfatal 'The combination TDX_IMX_HAB_ENABLE="0" and TDX_UBOOT_HARDENING_ENABLE="1" is not allowed:' \
+                'the whitelisting feature (part of the hardening) currently relies on HAB/AHAB.'
+    fi
+}
+
+do_compile:prepend:k3() {
+    if [ "${TDX_K3_HSSE_ENABLE}" = "0" ] && [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
+        bbfatal 'The combination TDX_K3_HSSE_ENABLE="0" and TDX_UBOOT_HARDENING_ENABLE="1" is not allowed:' \
+                'the whitelisting feature (part of the hardening) currently relies on K3.'
+    fi
+}
+
+do_compile:prepend:k3r5() {
+    # TODO: Consider implementing some kind of hardening for the R5 processor.
+    if [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
+        bbfatal 'The hardening cannot be enabled for the R5 processor at the moment;' \
+	        'please review your setting of TDX_UBOOT_HARDENING_ENABLE.'
     fi
 }


### PR DESCRIPTION
See commit messages for details.

Note: the implementation was tested on an "open" device only.