### PR TITLE
Adapt hardening to AM62 (kirkstone)

### DIFF
--- a/classes/tdx-signed-fit-image.inc
+++ b/classes/tdx-signed-fit-image.inc
@@ -17,6 +17,7 @@ FIT_KEY_REQ_ARGS ?= "-batch -new"
 FIT_KEY_SIGN_PKCS ?= "-x509"
 
 # parameters to sign FIT images
+FIT_HASH_ALG ?= "sha256"
 FIT_SIGN_ALG ?= "rsa2048"
 FIT_SIGN_NUMBITS ?= "2048"
 FIT_SIGN_INDIVIDUAL = "0"

--- a/classes/tdx-signed-fit-image.inc
+++ b/classes/tdx-signed-fit-image.inc
@@ -21,3 +21,14 @@ FIT_HASH_ALG ?= "sha256"
 FIT_SIGN_ALG ?= "rsa2048"
 FIT_SIGN_NUMBITS ?= "2048"
 FIT_SIGN_INDIVIDUAL = "0"
+
+# stronger assignments to override settings in meta-ti
+#
+# NOTICE: a side effect of these assignments is that users will need to use
+#         :forcevariable (or an override stronger than :k3) to set them.
+UBOOT_SIGN_KEYDIR:k3 ?= "${TOPDIR}/keys/fit"
+UBOOT_SIGN_KEYNAME:k3 ?= "dev"
+UBOOT_SIGN_IMG_KEYNAME:k3 ?= "dev2"
+FIT_HASH_ALG:k3 ?= "sha256"
+FIT_SIGN_ALG:k3 ?= "rsa2048"
+FIT_SIGN_NUMBITS:k3 ?= "2048"

--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -1,8 +1,8 @@
 # Enable the Secure Boot hardening of U-Boot by Toradex.
 #
-# Currently the hardening implementation requires HAB/AHAB to be enabled so that
-# the combination TDX_IMX_HAB_ENABLE="0" TDX_UBOOT_HARDENING_ENABLE="1" is not
-# valid.
+# Currently the hardening implementation requires HAB/AHAB (or equivalent
+# technology in TI SoCs) to be enabled so that the combination
+# TDX_IMX_HAB_ENABLE="0" and TDX_UBOOT_HARDENING_ENABLE="1" is not valid.
 #
 # Also the hardening itself is supposed to protect the second link of the chain
 # of trust i.e. the link between bootloader and the kernel artifacts. So, the
@@ -13,12 +13,18 @@
 # UBOOT_SIGN_ENABLE are set, by default.
 #
 def default_tdx_uboot_hardening_enable(d):
-    if (bb.utils.to_boolean(d.getVar('TDX_IMX_HAB_ENABLE')) and
+    if ('imx-generic-bsp' in d.getVar('OVERRIDES').split(':') and
+        bb.utils.to_boolean(d.getVar('TDX_IMX_HAB_ENABLE')) and
+        bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE'))):
+        return True
+    if ('k3' in d.getVar('OVERRIDES').split(':') and
+        bb.utils.to_boolean(d.getVar('TDX_K3_HSSE_ENABLE')) and
         bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE'))):
         return True
     return False
 
 TDX_UBOOT_HARDENING_ENABLE ?= "${@'1' if default_tdx_uboot_hardening_enable(d) else '0'}"
+TDX_UBOOT_HARDENING_ENABLE:verdin-am62-k3r5 = "0"
 
 # Configure the "kernel command-line protection"; with this protection, the
 # fixed part of the bootargs are saved into the FIT image and checked against

--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -40,6 +40,7 @@ TDX_SECBOOT_REQUIRED_BOOTARGS:apalis-imx8 ?= "ro rootwait console=tty1 console=t
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mm ?= "ro rootwait console=tty1 console=ttymxc0,115200 consoleblank=0 earlycon"
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mp ?= "ro rootwait console=tty1 console=ttymxc2,115200 consoleblank=0 earlycon"
 TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx8x ?= "ro rootwait console=tty1 console=ttyLP3,115200 consoleblank=0 earlycon"
+TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-am62 ?= "ro rootwait console=tty1 console=ttyS2,115200 consoleblank=0 earlycon=ns16550a,mmio32,0x02800000"
 
 # Name of the overlay file (without extension) that will contain the fixed part
 # of the kernel command line; this will be stored inside the FIT image; notice

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -113,6 +113,10 @@ A few variables can be used to configure this feature, including:
 
 The complete list of variables can be found in the `tdx-signed-fit-image.inc` file.
 
+### Configuring FIT image signing / known issues
+
+- On the **Verdin AM62** SoM, some of the configuration variables (e.g. `UBOOT_SIGN_KEYDIR`, `UBOOT_SIGN_KEYNAME` (check the complete list in `tdx-signed-fit-image.inc`)) are set through override `k3` to ensure the values coming from layer `meta-toradex-security` override those from layer `meta-ti-bsp`. Due to this, the recommended way to set those variables is via override `forcevariable`.
+
 ## Configuring rootfs image signing
 
 When the `tdxref-signed` class is inherited, the rootfs image will be generated using the `dm-verity` kernel feature.

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -65,9 +65,11 @@ The hardening features above are controlled by the following variables:
 
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
-| `TDX_UBOOT_HARDENING_ENABLE` | Enable hardening features as a whole | `1` if both `TDX_IMX_HAB_ENABLE` and `UBOOT_SIGN_ENABLE` are set; `0` otherwise |
+| `TDX_UBOOT_HARDENING_ENABLE` | Enable hardening features as a whole | `1` if both secure boot support (controlled by variable `TDX_IMX_HAB_ENABLE` (NXP) or `TDX_K3_HSSE_ENABLE` (TI)) and FIT signing (controlled by `UBOOT_SIGN_ENABLE`) are enabled; `0` otherwise |
 | `TDX_SECBOOT_REQUIRED_BOOTARGS` | Expected value for the fixed part of the kernel command line | Different value for each machine |
 | `TDX_AMEND_BOOT_SCRIPT` | When set to `1` the boot script will be amended to make it suitable for secure boot; this only works with the script provided by Toradex for BSP reference images; users employing a custom script should set this to `0` | Same value as variable `TDX_UBOOT_HARDENING_ENABLE` |
+
+### U-Boot hardening / setup
 
 The behavior of the different hardening features can be set via the control FDT (see [Devicetree Control in U-Boot](https://u-boot.readthedocs.io/en/stable/develop/devicetree/control.html)). Setting the control FDT at build time can be achieved by adding extra device-tree [.dtsi fragments](https://u-boot.readthedocs.io/en/stable/develop/devicetree/control.html#external-dtsi-fragments) to U-Boot and setting the Kconfig variable `CONFIG_DEVICE_TREE_INCLUDES` appropriately; with Yocto/OE this would normally involve adding small patches to U-Boot and appending changes to its recipe but the details are outside the scope of the present document.
 
@@ -94,6 +96,10 @@ The following device-tree fragment shows all the nodes and properties that can b
 The command categories are currently only available as part of a [patch](./recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch) in header `cmd-categories.h`. The default FDT is part of another [patch](./recipes-bsp/u-boot/files/0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch) in file `tdx-secboot.dtsi`.
 
 <!-- TODO: Make more user-friendly instructions on setting the control FDT. -->
+
+### U-Boot hardening / known issues
+
+- On the **Verdin AM62** SoM, the hardening does not cover the bootloader running on the R5 processor (the boot master); we have plans to evaluate the need for such a protection and implementing it if actually needed.
 
 ## Configuring FIT image signing
 
@@ -136,7 +142,3 @@ When `tdxref-signed` is used to enable secure boot, the rootfs image is generate
 Because `dm-verity` is read-only, you might want to create an additional partition in the eMMC to store persistent data.
 
 If that is the case, you can use the `tdx-tezi-data-partition` class. For more information, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).
-
-## Known issues and limitations
-
-- Currently the hardening is implemented/integrated on NXP SoCs only; when building for other SoC vendors one has to disable the feature (set `TDX_UBOOT_HARDENING_ENABLE=` to `0`) or the build will fail.

--- a/dynamic-layers/toradex-nxp/recipes-kernel/linux/device-tree-overlays-ti_%.bbappend
+++ b/dynamic-layers/toradex-nxp/recipes-kernel/linux/device-tree-overlays-ti_%.bbappend
@@ -1,0 +1,1 @@
+require ${@ 'recipes-kernel/linux/add-secboot-kargs-overlay.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}

--- a/recipes-bsp/u-boot/files/0001-toradex-add-helper-to-detect-closed-k3-based-device-.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-add-helper-to-detect-closed-k3-based-device-.patch
@@ -1,0 +1,35 @@
+From db54f2591af7bc0e09654fdf86f59fd6d62e25e2 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Wed, 9 Oct 2024 20:23:16 -0300
+Subject: [PATCH 1/2] toradex: add helper to detect closed k3-based device
+ (am62)
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ arch/arm/mach-k3/common.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm/mach-k3/common.c b/arch/arm/mach-k3/common.c
+index 1a334bc435f..3f0f96c3012 100644
+--- a/arch/arm/mach-k3/common.c
++++ b/arch/arm/mach-k3/common.c
+@@ -464,6 +464,14 @@ static const char *get_device_type_name(void)
+ 	}
+ }
+ 
++#if defined(CONFIG_TDX_SECBOOT_HARDENING)
++int tdx_secboot_k3_dev_is_closed(void)
++{
++	/* Device is closed (security enforced (SE) state). */
++	return (get_device_type() == K3_DEVICE_TYPE_HS_SE);
++}
++#endif
++
+ int print_cpuinfo(void)
+ {
+ 	struct udevice *soc;
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-common-add-command-whitelisting-modules.patch
@@ -1,7 +1,7 @@
-From 48a9bffb1528563e8eca3e3774d9f409d51f47d7 Mon Sep 17 00:00:00 2001
+From d1963366ba5949abd3fc076c3496116ef1c02eba Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:28:50 -0300
-Subject: [PATCH 1/8] toradex: common: add command whitelisting modules
+Subject: [PATCH 01/10] toradex: common: add command whitelisting modules
 
 Add modules implementing the command whitelisting feature to be
 integrated into U-Boot on a separate commit.
@@ -288,7 +288,7 @@ index 00000000000..fb8aaa5eed0
 +#endif
 diff --git a/common/whitelist.c b/common/whitelist.c
 new file mode 100644
-index 00000000000..462df6709d2
+index 00000000000..ac460202124
 --- /dev/null
 +++ b/common/whitelist.c
 @@ -0,0 +1,841 @@

--- a/recipes-bsp/u-boot/files/0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch
+++ b/recipes-bsp/u-boot/files/0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch
@@ -1,7 +1,8 @@
-From 92b58da04f884a294d4e987544ae8556d4873ce4 Mon Sep 17 00:00:00 2001
+From 14f1ebaa57b6012edf4021e632793a98b75fbccf Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Tue, 22 Aug 2023 22:56:24 -0300
-Subject: [PATCH 2/8] toradex: dts: add fragment file to configure secure boot
+Subject: [PATCH 02/10] toradex: dts: add fragment file to configure secure
+ boot
 
 Add to the source tree the file 'tdx-secboot.dtsi' having the default
 configuration for the Toradex "Secure Boot"-related features. If built

--- a/recipes-bsp/u-boot/files/0002-toradex-support-detecting-closed-k3-based-device-am6.patch
+++ b/recipes-bsp/u-boot/files/0002-toradex-support-detecting-closed-k3-based-device-am6.patch
@@ -1,0 +1,31 @@
+From 8a37dbfea29bf6e70b25915cb797c1c99153d30e Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Wed, 9 Oct 2024 20:28:32 -0300
+Subject: [PATCH 2/2] toradex: support detecting closed k3-based device (am62)
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/tdx-harden.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/common/tdx-harden.c b/common/tdx-harden.c
+index 3fd7e8873ac..c6360abb33e 100644
+--- a/common/tdx-harden.c
++++ b/common/tdx-harden.c
+@@ -144,6 +144,11 @@ static int _tdx_secboot_dev_is_open(void)
+ 	default:	/* Unknown */
+ 		break;
+ 	}
++#elif defined(CONFIG_ARCH_K3)
++	int tdx_secboot_k3_dev_is_closed(void);
++	if (tdx_secboot_k3_dev_is_closed()) {
++		return 0;
++	}
+ #else
+ #error Neither CONFIG_IMX_HAB nor CONFIG_AHAB_BOOT is set
+ #endif
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-am62.patch
+++ b/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-am62.patch
@@ -1,0 +1,96 @@
+From 3bbd917bef13b299749906f4fdad3e609d08fdc3 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Mon, 28 Aug 2023 13:29:34 -0300
+Subject: [PATCH 3/8] toradex: integrate command whitelisting (am62)
+
+Integrate the command whitelisting feature which is part of the Secure
+Boot hardening on U-Boot made by Toradex. The feature allows categories
+of commands to be enabled/disabled depending on whether the device is
+in open/closed state related to HAB/AHAB; the selection of allowed and
+denied categories is taken from the control DTB having also hard-coded
+sane defaults.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ Kconfig          | 28 ++++++++++++++++++++++++++++
+ common/Makefile  |  2 ++
+ common/command.c |  5 +++++
+ 3 files changed, 35 insertions(+)
+
+diff --git a/Kconfig b/Kconfig
+index d6d905c1a7e..af670bac628 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -610,3 +610,31 @@ source "lib/Kconfig"
+ source "test/Kconfig"
+ 
+ source "tools/Kconfig"
++
++config TDX_SECBOOT_HARDENING
++	bool "Toradex Secure Boot hardening"
++	select TDX_CMD_WHITELIST
++	help
++	  This causes the Secure Boot hardening features added by Toradex
++	  to be built into U-Boot, including:
++
++	  - Command white-listing.
++	  - Protection against execution of unsigned software by "bootm".
++	  - CLI access prevention (when device is closed).
++	  - Kernel command line protection.
++
++	  Whether these features are active or not will depend on the runtime
++	  configuration stored in the control DTB.
++
++config TDX_SECBOOT_HARDENING_DBG
++	bool "Toradex Secure Boot hardening debugging support"
++	depends on TDX_SECBOOT_HARDENING
++	default n
++	help
++	  Add some extra commands to help debug the U-Boot hardening changes
++	  made by Toradex. This should never be enabled in production!
++
++config TDX_CMD_WHITELIST
++	bool
++	help
++	  Enable the command white-listing feature provided by Toradex.
+diff --git a/common/Makefile b/common/Makefile
+index fb83adac9ab..ea102796d0a 100644
+--- a/common/Makefile
++++ b/common/Makefile
+@@ -22,6 +22,8 @@ obj-$(CONFIG_$(SPL_TPL_)OF_LIBFDT) += fdt_support.o
+ obj-$(CONFIG_MII) += miiphyutil.o
+ obj-$(CONFIG_CMD_MII) += miiphyutil.o
+ obj-$(CONFIG_PHYLIB) += miiphyutil.o
++obj-$(CONFIG_TDX_SECBOOT_HARDENING) += tdx-harden.o
++obj-$(CONFIG_TDX_CMD_WHITELIST) += whitelist.o
+ 
+ obj-$(CONFIG_USB_HOST) += usb.o usb_hub.o
+ obj-$(CONFIG_USB_GADGET) += usb.o
+diff --git a/common/command.c b/common/command.c
+index 846e16e2ada..6e675896eb7 100644
+--- a/common/command.c
++++ b/common/command.c
+@@ -18,6 +18,7 @@
+ #include <mapmem.h>
+ #include <asm/global_data.h>
+ #include <linux/ctype.h>
++#include <tdx-harden.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -579,6 +580,10 @@ static int cmd_call(struct cmd_tbl *cmdtp, int flag, int argc,
+ {
+ 	int result;
+ 
++#ifdef CONFIG_TDX_CMD_WHITELIST
++	if (!cmd_allowed_by_whitelist(cmdtp, argc, argv))
++		return CMD_RET_FAILURE;
++#endif
+ 	result = cmdtp->cmd_rep(cmdtp, flag, argc, argv, repeatable);
+ 	if (result)
+ 		debug("Command failed, result=%d\n", result);
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-am62.patch
+++ b/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-am62.patch
@@ -1,7 +1,7 @@
 From 3bbd917bef13b299749906f4fdad3e609d08fdc3 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:29:34 -0300
-Subject: [PATCH 3/8] toradex: integrate command whitelisting (am62)
+Subject: [PATCH 03/10] toradex: integrate command whitelisting (am62)
 
 Integrate the command whitelisting feature which is part of the Secure
 Boot hardening on U-Boot made by Toradex. The feature allows categories

--- a/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-downstream.patch
+++ b/recipes-bsp/u-boot/files/0003-toradex-integrate-command-whitelisting-downstream.patch
@@ -1,7 +1,7 @@
-From fcd42429f286bf8df8a9a3f30801f1a9082d6eee Mon Sep 17 00:00:00 2001
+From 222f6c8ef17b084e78a38bf1e18c9442f3a50ec1 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:29:34 -0300
-Subject: [PATCH 3/8] toradex: integrate command whitelisting (downstream)
+Subject: [PATCH 03/10] toradex: integrate command whitelisting (downstream)
 
 Integrate the command whitelisting feature which is part of the Secure
 Boot hardening on U-Boot made by Toradex. The feature allows categories

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-am62.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-am62.patch
@@ -1,0 +1,141 @@
+From d88b5ee767ce6e296946264ee5f4e8469e67fb36 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 7 Sep 2023 23:54:48 -0300
+Subject: [PATCH 4/8] toradex: integrate bootm protection (am62)
+
+Integrate the protection to the bootm command to only allow booting
+from FIT images. With the proper configuration of U-Boot (enabling FIT
+signing) one can ensure only signed FIT images can be booted when the
+hardening is enabled at runtime.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ Kconfig      |  7 ++++++
+ boot/bootm.c | 65 +++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 71 insertions(+), 1 deletion(-)
+
+diff --git a/Kconfig b/Kconfig
+index af670bac628..c843e29d1cd 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -614,6 +614,7 @@ source "tools/Kconfig"
+ config TDX_SECBOOT_HARDENING
+ 	bool "Toradex Secure Boot hardening"
+ 	select TDX_CMD_WHITELIST
++	select TDX_BOOTM_PROTECTION
+ 	help
+ 	  This causes the Secure Boot hardening features added by Toradex
+ 	  to be built into U-Boot, including:
+@@ -638,3 +639,9 @@ config TDX_CMD_WHITELIST
+ 	bool
+ 	help
+ 	  Enable the command white-listing feature provided by Toradex.
++
++config TDX_BOOTM_PROTECTION
++	bool
++	help
++	  Enable the protection in bootm to prevent execution of unsigned
++	  images.
+diff --git a/boot/bootm.c b/boot/bootm.c
+index 4144ff3b031..19a6689a50f 100644
+--- a/boot/bootm.c
++++ b/boot/bootm.c
+@@ -32,6 +32,7 @@
+ #include <command.h>
+ #include <bootm.h>
+ #include <image.h>
++#include <tdx-harden.h>
+ 
+ #define MAX_CMDLINE_SIZE	SZ_4K
+ 
+@@ -72,7 +73,29 @@ static int bootm_start(struct cmd_tbl *cmdtp, int flag, int argc,
+ 		       char *const argv[])
+ {
+ 	memset((void *)&images, 0, sizeof(images));
++
++#if CONFIG_IS_ENABLED(TDX_BOOTM_PROTECTION)
++	/*
++	 * When the "bootm" protection is enabled at build-time, FIT signature
++	 * verification is supposed to follow the status of the hardening. For
++	 * this, we assume CONFIG_FIT_SIGNATURE is set and here we set the
++	 * value of the "verify" field to match the status of the hardening.
++	 * With this we have:
++	 *
++	 * - If hardening is enabled => validate/enforce correct signature.
++	 * - If hardening is disabled => do not check signature.
++	 *
++	 * The logic above should be appropriate for allowing a bootloader
++	 * binary to be altered between non-secure and secure modes. Notice
++	 * that when this "bootm" protection is enabled the environment
++	 * variable "verify" is no longer used at the moment.
++	 *
++	 * TODO: Consider adding "verify" as part of the logic.
++	 */
++	images.verify = tdx_hardening_enabled();
++#else
+ 	images.verify = env_get_yesno("verify");
++#endif
+ 
+ 	boot_start_lmb(&images);
+ 
+@@ -895,6 +918,7 @@ static const void *boot_get_kernel(struct cmd_tbl *cmdtp, int flag, int argc,
+ 	struct legacy_img_hdr	*hdr;
+ #endif
+ 	ulong		img_addr;
++	int		fmt;
+ 	const void *buf;
+ 	const char	*fit_uname_config = NULL;
+ 	const char	*fit_uname_kernel = NULL;
+@@ -918,7 +942,46 @@ static const void *boot_get_kernel(struct cmd_tbl *cmdtp, int flag, int argc,
+ 	/* check image type, for FIT images get FIT kernel node */
+ 	*os_data = *os_len = 0;
+ 	buf = map_sysmem(img_addr, 0);
+-	switch (genimg_get_format(buf)) {
++	fmt = genimg_get_format(buf);
++
++#if CONFIG_IS_ENABLED(TDX_BOOTM_PROTECTION)
++	if (tdx_hardening_enabled()) {
++		/* hardening enabled at runtime. */
++		if (fmt != IMAGE_FORMAT_FIT) {
++			/* accept FIT images only. */
++			puts("ERROR: can't boot from non-FIT images with "
++			     "hardening enabled.\n");
++			return NULL;
++		}
++
++		/*
++		 * For TorizonCore we expect a configuration to be always passed
++		 * by the boot script; at the CLI level this means the usage
++		 * syntax would be this one:
++		 *
++		 * bootm [<addr1>]#<conf>[#<extra-conf[#...]]
++		 *
++		 * Since one can easily bypass the signature checks by directly
++		 * specifying the kernel/ramdisk/fdt, here we enforce the above
++		 * usage where a <conf> name is passed in which case the
++		 * signature validation is performed for the configuration
++		 * (which then covers the images). This is done by requiring
++		 * 'fit_uname_config' to be non-null. As an extra caution, we
++		 * also enforce variable 'fit_uname_kernel' not to be null to
++		 * prevent the use where a kernel image is specified directly,
++		 * i.e. not via a configuration.
++		 *
++		 */
++		if ((argc != 1) ||
++		    (fit_uname_config == NULL) || (fit_uname_kernel != NULL)) {
++			puts("ERROR: bootm only accepts booting from a "
++			     "configuration when hardening is enabled.\n");
++			return NULL;
++		}
++	}
++#endif
++
++	switch (fmt) {
+ #if CONFIG_IS_ENABLED(LEGACY_IMAGE_FORMAT)
+ 	case IMAGE_FORMAT_LEGACY:
+ 		printf("## Booting kernel from Legacy Image at %08lx ...\n",
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-am62.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-am62.patch
@@ -1,7 +1,7 @@
 From d88b5ee767ce6e296946264ee5f4e8469e67fb36 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 7 Sep 2023 23:54:48 -0300
-Subject: [PATCH 4/8] toradex: integrate bootm protection (am62)
+Subject: [PATCH 04/10] toradex: integrate bootm protection (am62)
 
 Integrate the protection to the bootm command to only allow booting
 from FIT images. With the proper configuration of U-Boot (enabling FIT

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootm-protection-downstream.patch
@@ -1,7 +1,7 @@
-From 56ca935500dfc64d82d4ccca74e94819ee0e96f0 Mon Sep 17 00:00:00 2001
+From d5b52d80aadc25521213ebb105a47a968b293172 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 7 Sep 2023 23:54:48 -0300
-Subject: [PATCH 4/8] toradex: integrate bootm protection (downstream)
+Subject: [PATCH 04/10] toradex: integrate bootm protection (downstream)
 
 Integrate the protection to the bootm command to only allow booting
 from FIT images. With the proper configuration of U-Boot (enabling FIT

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-am62.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-am62.patch
@@ -1,7 +1,7 @@
 From 87d37b57fbe839a4e41b8bc215a7cc841ae7ae30 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 13 Sep 2023 15:22:25 -0300
-Subject: [PATCH 5/8] toradex: integrate CLI access protection (am62)
+Subject: [PATCH 05/10] toradex: integrate CLI access protection (am62)
 
 Integrate the protection in U-Boot to prevent access to its CLI once
 the device is closed; this is part of the hardening for Secure Boot.

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-am62.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-am62.patch
@@ -1,0 +1,167 @@
+From 87d37b57fbe839a4e41b8bc215a7cc841ae7ae30 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Wed, 13 Sep 2023 15:22:25 -0300
+Subject: [PATCH 5/8] toradex: integrate CLI access protection (am62)
+
+Integrate the protection in U-Boot to prevent access to its CLI once
+the device is closed; this is part of the hardening for Secure Boot.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ Kconfig              |  7 ++++++
+ common/main.c        |  5 ++++
+ common/tdx-harden.c  | 55 ++++++++++++++++++++++++++++++++++++++++++++
+ include/tdx-harden.h |  5 +++-
+ 4 files changed, 71 insertions(+), 1 deletion(-)
+
+diff --git a/Kconfig b/Kconfig
+index c843e29d1cd..f60212579ce 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -615,6 +615,7 @@ config TDX_SECBOOT_HARDENING
+ 	bool "Toradex Secure Boot hardening"
+ 	select TDX_CMD_WHITELIST
+ 	select TDX_BOOTM_PROTECTION
++	select TDX_CLI_PROTECTION
+ 	help
+ 	  This causes the Secure Boot hardening features added by Toradex
+ 	  to be built into U-Boot, including:
+@@ -645,3 +646,9 @@ config TDX_BOOTM_PROTECTION
+ 	help
+ 	  Enable the protection in bootm to prevent execution of unsigned
+ 	  images.
++
++config TDX_CLI_PROTECTION
++	bool
++	help
++	  Enable the protection where the CLI is disabled when the device
++	  is in closed state.
+diff --git a/common/main.c b/common/main.c
+index 682f3359ea3..fc36c44a438 100644
+--- a/common/main.c
++++ b/common/main.c
+@@ -17,6 +17,7 @@
+ #include <net.h>
+ #include <version_string.h>
+ #include <efi_loader.h>
++#include <tdx-harden.h>
+ 
+ static void run_preboot_environment_command(void)
+ {
+@@ -61,6 +62,10 @@ void main_loop(void)
+ 	}
+ 
+ 	s = bootdelay_process();
++#if CONFIG_IS_ENABLED(TDX_CLI_PROTECTION)
++	if (!tdx_cli_access_enabled())
++		tdx_secure_boot_cmd(s); 	/* no return */
++#endif
+ 	if (cli_process_fdt(&s))
+ 		cli_secure_boot_cmd(s);
+ 
+diff --git a/common/tdx-harden.c b/common/tdx-harden.c
+index fb8aaa5eed0..1134b6ce596 100644
+--- a/common/tdx-harden.c
++++ b/common/tdx-harden.c
+@@ -6,6 +6,7 @@
+ #include <common.h>
+ #include <compiler.h>
+ #include <command.h>
++#include <console.h>
+ #include <log.h>
+ #include <fdt_support.h>
+ #include <asm/global_data.h>
+@@ -160,6 +161,55 @@ int tdx_secboot_dev_is_open(void)
+ 	return dev_open;
+ }
+ 
++#ifdef CONFIG_TDX_CLI_PROTECTION
++/**
++ * tdx_cli_access_enabled - Determine if U-Boot CLI access is to be enabled
++ * Return: 1 if CLI access is to be enabled or 0 otherwise.
++ */
++int tdx_cli_access_enabled(void)
++{
++	const void *en_prop;
++	int secboot_offset, prop_len;
++
++	if (!tdx_hardening_enabled())
++		return 1;
++	if (tdx_secboot_dev_is_open())
++		return 1;
++	if (!gd->fdt_blob)
++		return 1;	/* no hardening */
++
++	secboot_offset = fdt_path_offset(gd->fdt_blob, secboot_node_path);
++	if (secboot_offset < 0)
++		return 1;	/* no hardening */
++
++	/* Hardening is enabled and device is closed: CLI access should be
++	   disabled unless the control DTB says otherwise: check it.  */
++	en_prop = fdt_getprop(gd->fdt_blob, secboot_offset,
++			       "enable-cli-when-closed", &prop_len);
++	if (en_prop) {
++		debug("U-Boot CLI access enabled by property (len=%d)\n",
++		      prop_len);
++		return 1;
++	}
++
++	debug("U-Boot CLI access disabled\n");
++	return 0;
++}
++
++void tdx_secure_boot_cmd(const char *cmd)
++{
++	int rc;
++
++	printf("## U-Boot CLI access is disabled due to Secure Boot\n");
++
++	disable_ctrlc(1);
++	rc = run_command_list(cmd, -1, 0);
++
++	panic("## ERROR: \"%s\" returned (code %d) and CLI access is "
++	      "disabled\n", cmd, rc);
++}
++#endif
++
+ static int hardening_info(void)
+ {
+ 	int hdn_enabled = tdx_hardening_enabled();
+@@ -258,3 +308,8 @@ U_BOOT_CMD(hardening, 5, 0, do_hardening,
+  * U-Boot configuration is wrong. */
+ #error Toradex hardening assumes CONFIG_LMB is set
+ #endif
++
++#ifdef CONFIG_UPDATE_TFTP
++/* Self-updates are likely not safe. */
++#error Toradex hardening assumes CONFIG_UPDATE_TFTP is not set
++#endif
+diff --git a/include/tdx-harden.h b/include/tdx-harden.h
+index dfdaa69d3a4..50e850ba2af 100644
+--- a/include/tdx-harden.h
++++ b/include/tdx-harden.h
+@@ -12,6 +12,8 @@
+  *     chosen {
+  *         toradex,secure-boot {    [if not present: disable Toradex hardening]
+  *             disabled;                  [optional: disable Toradex hardening]
++ *             enable-cli-when-closed; [optional: keep u-boot cli enabled when]
++                                                          [...device is closed]
+  *             bootloader-commands {
+  *                 allow-open = <CMD_CAT_ALL>;
+  *                 allow-closed = <CMD_CAT_NEEDED CMD_CAT_SAFE>;
+@@ -35,8 +37,9 @@
+ struct cmd_tbl;
+ 
+ int cmd_allowed_by_whitelist(struct cmd_tbl *cmd, int argc, char *const argv[]);
+-
+ int tdx_secboot_dev_is_open(void);
+ int tdx_hardening_enabled(void);
++int tdx_cli_access_enabled(void);
++void tdx_secure_boot_cmd(const char *cmd);
+ 
+ #endif	/* __TDX_HARDEN_H */
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-CLI-access-protection-downstream.patch
@@ -1,7 +1,7 @@
-From 8a2aa56d770e6d381ec0ed150a0c55be9144f3b2 Mon Sep 17 00:00:00 2001
+From 5c4dcda9dcf466473fe5b7b0bb3298e836426f72 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 13 Sep 2023 15:22:25 -0300
-Subject: [PATCH 5/8] toradex: integrate CLI access protection (downstream)
+Subject: [PATCH 05/10] toradex: integrate CLI access protection (downstream)
 
 Integrate the protection in U-Boot to prevent access to its CLI once
 the device is closed; this is part of the hardening for Secure Boot.

--- a/recipes-bsp/u-boot/files/0007-toradex-add-implementation-of-bootargs-protection.patch
+++ b/recipes-bsp/u-boot/files/0007-toradex-add-implementation-of-bootargs-protection.patch
@@ -1,7 +1,7 @@
-From 242b368c9a84863984e6f787762100af03298f10 Mon Sep 17 00:00:00 2001
+From 2cb9e2a2aaa6859ee9b22a91aeaf2b01fb9b6041 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 6 Nov 2023 22:25:28 -0300
-Subject: [PATCH 7/8] toradex: add implementation of bootargs protection
+Subject: [PATCH 07/10] toradex: add implementation of bootargs protection
 
 This only adds the code implementing the feature but does not integrate
 it into U-Boot.
@@ -15,7 +15,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  2 files changed, 238 insertions(+), 2 deletions(-)
 
 diff --git a/common/tdx-harden.c b/common/tdx-harden.c
-index 1134b6ce596..4061bc85eac 100644
+index 1134b6ce596..82ff38a7fe1 100644
 --- a/common/tdx-harden.c
 +++ b/common/tdx-harden.c
 @@ -3,12 +3,18 @@

--- a/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-am62.patch
+++ b/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-am62.patch
@@ -1,7 +1,7 @@
 From 8c9be8ad67f61becf293676696575e0e85a0a69a Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 26 Oct 2023 12:40:46 -0300
-Subject: [PATCH 8/8] toradex: integrate bootargs protection (am62)
+Subject: [PATCH 08/10] toradex: integrate bootargs protection (am62)
 
 Upstream-Status: Inappropriate [TorizonCore specific]
 

--- a/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-am62.patch
+++ b/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-am62.patch
@@ -1,0 +1,79 @@
+From 8c9be8ad67f61becf293676696575e0e85a0a69a Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 26 Oct 2023 12:40:46 -0300
+Subject: [PATCH 8/8] toradex: integrate bootargs protection (am62)
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ Kconfig              | 10 ++++++++++
+ common/fdt_support.c | 20 ++++++++++++++++++++
+ 2 files changed, 30 insertions(+)
+
+diff --git a/Kconfig b/Kconfig
+index f60212579ce..f3d3132334e 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -616,6 +616,7 @@ config TDX_SECBOOT_HARDENING
+ 	select TDX_CMD_WHITELIST
+ 	select TDX_BOOTM_PROTECTION
+ 	select TDX_CLI_PROTECTION
++	select TDX_BOOTARGS_PROTECTION
+ 	help
+ 	  This causes the Secure Boot hardening features added by Toradex
+ 	  to be built into U-Boot, including:
+@@ -652,3 +653,12 @@ config TDX_CLI_PROTECTION
+ 	help
+ 	  Enable the protection where the CLI is disabled when the device
+ 	  is in closed state.
++
++config TDX_BOOTARGS_PROTECTION
++	bool
++	help
++	  Enable the protection for the kernel command line (bootargs); with
++	  this feature, U-Boot will check the "bootargs" environment variable
++	  against information in the device-tree provided to the bootm
++	  command. Since the device-tree is supposed to come from a signed
++	  FIT image, it is expected to be a trustworthy source of information.
+diff --git a/common/fdt_support.c b/common/fdt_support.c
+index 0e2f12bd09c..1345092f9d3 100644
+--- a/common/fdt_support.c
++++ b/common/fdt_support.c
+@@ -25,6 +25,10 @@
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
++#ifdef CONFIG_TDX_BOOTARGS_PROTECTION
++#include <tdx-harden.h>
++#endif
++
+ /**
+  * fdt_getprop_u32_default_node - Return a node's property or a default
+  *
+@@ -312,6 +316,22 @@ int fdt_chosen(void *fdt)
+ 
+ 	str = board_fdt_chosen_bootargs();
+ 
++#ifdef CONFIG_TDX_BOOTARGS_PROTECTION
++	if (tdx_hardening_enabled()) {
++		if (tdx_valid_bootargs(fdt, str)) {
++			printf("## Validation of bootargs succeeded.\n");
++		} else if (tdx_secboot_dev_is_open()) {
++			eprintf("## WARNING: Allowing boot while device is "
++				"open; please fix bootargs before closing "
++				"device.\n");
++		} else {
++			eprintf("## FATAL: Stopping boot process due to "
++				"bootargs validation error.\n");
++			return -FDT_ERR_BADVALUE;
++		}
++	}
++#endif
++
+ 	if (str) {
+ 		err = fdt_setprop(fdt, nodeoffset, "bootargs", str,
+ 				  strlen(str) + 1);
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0008-toradex-integrate-bootargs-protection-downstream.patch
@@ -1,7 +1,7 @@
-From 2a9639b60a7cab00b703b67a3b8120ddd6b6b647 Mon Sep 17 00:00:00 2001
+From 1e0cc60ee70d0664a90f2bfe0ee816d5cad7e8f0 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 26 Oct 2023 12:40:46 -0300
-Subject: [PATCH 8/8] toradex: integrate bootargs protection (downstream)
+Subject: [PATCH 08/10] toradex: integrate bootargs protection (downstream)
 
 Upstream-Status: Inappropriate [TorizonCore specific]
 
@@ -37,7 +37,7 @@ index 0dbb1f87a89..d9241273b14 100644
 +	  command. Since the device-tree is supposed to come from a signed
 +	  FIT image, it is expected to be a trustworthy source of information.
 diff --git a/common/fdt_support.c b/common/fdt_support.c
-index f08915c2c66..5f4f07c8f61 100644
+index f08915c2c66..5acd54fc702 100644
 --- a/common/fdt_support.c
 +++ b/common/fdt_support.c
 @@ -21,6 +21,10 @@

--- a/recipes-bsp/u-boot/files/0009-toradex-show-message-if-CLI-access-allowed-common.patch
+++ b/recipes-bsp/u-boot/files/0009-toradex-show-message-if-CLI-access-allowed-common.patch
@@ -1,0 +1,82 @@
+From 1b6d7b53cd9a47551fe2d16f82c37d24d0bfc901 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 10 Oct 2024 00:38:50 -0300
+Subject: [PATCH 09/10] toradex: show message if CLI access allowed (common)
+
+Before, a message was shown only when the device was closed and the CLI
+access was disabled by the CLI protection feature. Now we show a message
+also when the device is open which is helpful when someone wants to
+ensure the protection is compiled in without having to close the device.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/tdx-harden.c  | 25 ++++++++++++++++++++-----
+ include/tdx-harden.h |  2 +-
+ 2 files changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/common/tdx-harden.c b/common/tdx-harden.c
+index 82ff38a7fe1..3fd7e8873ac 100644
+--- a/common/tdx-harden.c
++++ b/common/tdx-harden.c
+@@ -199,10 +199,9 @@ int tdx_secboot_dev_is_open(void)
+ 
+ #ifdef CONFIG_TDX_CLI_PROTECTION
+ /**
+- * tdx_cli_access_enabled - Determine if U-Boot CLI access is to be enabled
+- * Return: 1 if CLI access is to be enabled or 0 otherwise.
++ * TODO: Return status instead and show more detailed info in tdx_cli_access_enabled().
+  */
+-int tdx_cli_access_enabled(void)
++static int _tdx_cli_access_enabled(void)
+ {
+ 	const void *en_prop;
+ 	int secboot_offset, prop_len;
+@@ -232,12 +231,28 @@ int tdx_cli_access_enabled(void)
+ 	return 0;
+ }
+ 
++/**
++ * tdx_cli_access_enabled - Determine if U-Boot CLI access is to be enabled
++ * Return: 1 if CLI access is to be enabled or 0 otherwise.
++ */
++int tdx_cli_access_enabled(int showmsg)
++{
++	int res = _tdx_cli_access_enabled();
++	if (!showmsg)
++		return res;
++
++	if (res)
++		printf("## U-Boot CLI access is enabled\n");
++	else
++		printf("## U-Boot CLI access is disabled due to Secure Boot\n");
++
++	return res;
++}
++
+ void tdx_secure_boot_cmd(const char *cmd)
+ {
+ 	int rc;
+ 
+-	printf("## U-Boot CLI access is disabled due to Secure Boot\n");
+-
+ 	disable_ctrlc(1);
+ 	rc = run_command_list(cmd, -1, 0);
+ 
+diff --git a/include/tdx-harden.h b/include/tdx-harden.h
+index 1cb61aed45e..2209780b4c5 100644
+--- a/include/tdx-harden.h
++++ b/include/tdx-harden.h
+@@ -43,7 +43,7 @@ struct cmd_tbl;
+ int cmd_allowed_by_whitelist(struct cmd_tbl *cmd, int argc, char *const argv[]);
+ int tdx_secboot_dev_is_open(void);
+ int tdx_hardening_enabled(void);
+-int tdx_cli_access_enabled(void);
++int tdx_cli_access_enabled(int showmsg);
+ void tdx_secure_boot_cmd(const char *cmd);
+ int tdx_valid_bootargs(void *fdt, const char *bootargs);
+ 
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0010-toradex-show-message-if-CLI-access-allowed-am62.patch
+++ b/recipes-bsp/u-boot/files/0010-toradex-show-message-if-CLI-access-allowed-am62.patch
@@ -1,0 +1,33 @@
+From 9b9ac6300e2a02946fccb50099417b9a06e04908 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 10 Oct 2024 00:39:52 -0300
+Subject: [PATCH 10/10] toradex: show message if CLI access allowed (am62)
+
+Before, a message was shown only when the device was closed and the CLI
+access was disabled by the CLI protection feature. Now we show a message
+also when the device is open which is helpful when someone wants to
+ensure the protection is compiled in without having to close the device.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/main.c b/common/main.c
+index fc36c44a438..218834b3770 100644
+--- a/common/main.c
++++ b/common/main.c
+@@ -63,7 +63,7 @@ void main_loop(void)
+ 
+ 	s = bootdelay_process();
+ #if CONFIG_IS_ENABLED(TDX_CLI_PROTECTION)
+-	if (!tdx_cli_access_enabled())
++	if (!tdx_cli_access_enabled(1))
+ 		tdx_secure_boot_cmd(s); 	/* no return */
+ #endif
+ 	if (cli_process_fdt(&s))
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/files/0010-toradex-show-message-if-CLI-access-allowed-downstrea.patch
+++ b/recipes-bsp/u-boot/files/0010-toradex-show-message-if-CLI-access-allowed-downstrea.patch
@@ -1,0 +1,34 @@
+From f85a94e84f01a4762a7ebaa3a0058f29c93c5cc2 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 10 Oct 2024 00:39:52 -0300
+Subject: [PATCH 10/10] toradex: show message if CLI access allowed
+ (downstream)
+
+Before, a message was shown only when the device was closed and the CLI
+access was disabled by the CLI protection feature. Now we show a message
+also when the device is open which is helpful when someone wants to
+ensure the protection is compiled in without having to close the device.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/main.c b/common/main.c
+index 3662c0361e7..28eb98d3bda 100644
+--- a/common/main.c
++++ b/common/main.c
+@@ -60,7 +60,7 @@ void main_loop(void)
+ 
+ 	s = bootdelay_process();
+ #if CONFIG_IS_ENABLED(TDX_CLI_PROTECTION)
+-	if (!tdx_cli_access_enabled())
++	if (!tdx_cli_access_enabled(1))
+ 		tdx_secure_boot_cmd(s); 	/* no return */
+ #endif
+ 	if (cli_process_fdt(&s))
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -7,6 +7,8 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM = "\
     file://0006-arm-dts-add-missing-newline-to-eof-downstream.patch \
     file://0007-toradex-add-implementation-of-bootargs-protection.patch \
     file://0008-toradex-integrate-bootargs-protection-downstream.patch \
+    file://0009-toradex-show-message-if-CLI-access-allowed-common.patch \
+    file://0010-toradex-show-message-if-CLI-access-allowed-downstrea.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
@@ -18,6 +20,8 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
     file://0006-arm-dts-add-missing-newline-to-eof-am62.patch \
     file://0007-toradex-add-implementation-of-bootargs-protection.patch \
     file://0008-toradex-integrate-bootargs-protection-am62.patch \
+    file://0009-toradex-show-message-if-CLI-access-allowed-common.patch \
+    file://0010-toradex-show-message-if-CLI-access-allowed-am62.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
@@ -29,6 +33,8 @@ TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
     file://0006-arm-dts-add-missing-newline-to-eof-upstream.patch \
     file://0007-toradex-add-implementation-of-bootargs-protection.patch \
     file://0008-toradex-integrate-bootargs-protection-upstream.patch \
+    file://0009-toradex-show-message-if-CLI-access-allowed-common.patch \
+    file://0010-toradex-show-message-if-CLI-access-allowed-upstream.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES = "${TDX_UBOOT_HARDENING_PATCHES_UPSTREAM}"

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -41,8 +41,24 @@ SRC_URI:append = "\
     ${TDX_UBOOT_HARDENING_PATCHES} \
 "
 
-do_compile:prepend() {
+do_compile:prepend:imx-generic-bsp() {
     if [ "${TDX_IMX_HAB_ENABLE}" = "0" ] && [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
-        bbfatal 'The combination TDX_IMX_HAB_ENABLE = "0" and TDX_UBOOT_HARDENING_ENABLE = "1" is not allowed: the whitelisting feature (part of the hardening) currently relies on HAB/AHAB.'
+        bbfatal 'The combination TDX_IMX_HAB_ENABLE="0" and TDX_UBOOT_HARDENING_ENABLE="1" is not allowed:' \
+                'the whitelisting feature (part of the hardening) currently relies on HAB/AHAB.'
+    fi
+}
+
+do_compile:prepend:k3() {
+    if [ "${TDX_K3_HSSE_ENABLE}" = "0" ] && [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
+        bbfatal 'The combination TDX_K3_HSSE_ENABLE="0" and TDX_UBOOT_HARDENING_ENABLE="1" is not allowed:' \
+                'the whitelisting feature (part of the hardening) currently relies on K3.'
+    fi
+}
+
+do_compile:prepend:k3r5() {
+    # TODO: Consider implementing some kind of hardening for the R5 processor.
+    if [ "${TDX_UBOOT_HARDENING_ENABLE}" = "1" ]; then
+        bbfatal 'The hardening cannot be enabled for the R5 processor at the moment;' \
+	        'please review your setting of TDX_UBOOT_HARDENING_ENABLE.'
     fi
 }

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -1,5 +1,4 @@
-SRC_URI:append:use-nxp-bsp = "\
-    file://u-boot-harden.cfg \
+TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM = "\
     file://0001-toradex-common-add-command-whitelisting-modules.patch \
     file://0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch \
     file://0003-toradex-integrate-command-whitelisting-downstream.patch \
@@ -10,8 +9,18 @@ SRC_URI:append:use-nxp-bsp = "\
     file://0008-toradex-integrate-bootargs-protection-downstream.patch \
 "
 
-SRC_URI:append:use-mainline-bsp = "\
-    file://u-boot-harden.cfg \
+TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
+    file://0001-toradex-common-add-command-whitelisting-modules.patch \
+    file://0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch \
+    file://0003-toradex-integrate-command-whitelisting-am62.patch \
+    file://0004-toradex-integrate-bootm-protection-am62.patch \
+    file://0005-toradex-integrate-CLI-access-protection-am62.patch \
+    file://0006-arm-dts-add-missing-newline-to-eof-am62.patch \
+    file://0007-toradex-add-implementation-of-bootargs-protection.patch \
+    file://0008-toradex-integrate-bootargs-protection-am62.patch \
+"
+
+TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
     file://0001-toradex-common-add-command-whitelisting-modules.patch \
     file://0002-toradex-dts-add-fragment-file-to-configure-secure-bo.patch \
     file://0003-toradex-integrate-command-whitelisting-upstream.patch \
@@ -20,6 +29,16 @@ SRC_URI:append:use-mainline-bsp = "\
     file://0006-arm-dts-add-missing-newline-to-eof-upstream.patch \
     file://0007-toradex-add-implementation-of-bootargs-protection.patch \
     file://0008-toradex-integrate-bootargs-protection-upstream.patch \
+"
+
+TDX_UBOOT_HARDENING_PATCHES = "${TDX_UBOOT_HARDENING_PATCHES_UPSTREAM}"
+TDX_UBOOT_HARDENING_PATCHES:use-nxp-bsp = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM}"
+TDX_UBOOT_HARDENING_PATCHES:verdin-am62 = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62}"
+TDX_UBOOT_HARDENING_PATCHES:verdin-am62-k3r5 = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62}"
+
+SRC_URI:append = "\
+    file://u-boot-harden.cfg \
+    ${TDX_UBOOT_HARDENING_PATCHES} \
 "
 
 do_compile:prepend() {

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -22,6 +22,9 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
     file://0008-toradex-integrate-bootargs-protection-am62.patch \
     file://0009-toradex-show-message-if-CLI-access-allowed-common.patch \
     file://0010-toradex-show-message-if-CLI-access-allowed-am62.patch \
+    \
+    file://0001-toradex-add-helper-to-detect-closed-k3-based-device-.patch \
+    file://0002-toradex-support-detecting-closed-k3-based-device-am6.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\


### PR DESCRIPTION
Same as https://github.com/toradex/meta-toradex-security/pull/73 but for kirkstone.

Though kirkstone is entering maintenance mode, I ended up making this adaptation also in it just to avoid having a gap on the hardening feature just on the AM62 machine.

Note: the implementation was tested on an "open" device only.