### PR TITLE
optee: add support for Verdin iMX8MM (scarthgap)

### DIFF
--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -36,7 +36,10 @@ inherit ${@ 'tdx-tezi-data-partition' if 'teziimg' in d.getVar('IMAGE_FSTYPES') 
 addhandler validate_optee_support
 validate_optee_support[eventmask] = "bb.event.SanityCheck"
 python validate_optee_support() {
-    supported_machines = ['verdin-imx8mp']
+    supported_machines = [
+        'verdin-imx8mp',
+        'verdin-imx8mm',
+    ]
     machine = e.data.getVar('MACHINE')
     if machine not in supported_machines:
         bb.fatal("OP-TEE is currently not supported on '%s' machine!" % machine)

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -9,6 +9,7 @@ TEE might be a good solution to store and manage secrets (e.g. encryption keys) 
 This layer provides support for running OP-TEE on the following SoMs:
 
 - Verdin iMX8MP
+- Verdin iMX8MM
 
 ## Enabling OP-TEE
 

--- a/recipes-bsp/u-boot/files/0001-imx8mm-binman-add-tee-node.patch
+++ b/recipes-bsp/u-boot/files/0001-imx8mm-binman-add-tee-node.patch
@@ -1,0 +1,50 @@
+From 3270be365af6e202624dc7ba8f482c07b7c3a564 Mon Sep 17 00:00:00 2001
+From: Sergio Prado <sergio.prado@e-labworks.com>
+Date: Tue, 22 Oct 2024 08:23:36 -0300
+Subject: [PATCH] imx8mm: binman: add tee node
+
+Upstream-Status: Pending
+
+Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>
+---
+ arch/arm/dts/imx8mm-u-boot.dtsi | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/imx8mm-u-boot.dtsi b/arch/arm/dts/imx8mm-u-boot.dtsi
+index 6ab8f66256ed..4cef253d01f8 100644
+--- a/arch/arm/dts/imx8mm-u-boot.dtsi
++++ b/arch/arm/dts/imx8mm-u-boot.dtsi
+@@ -149,6 +149,19 @@
+ 					type = "firmware";
+ 				};
+ 
++				tee {
++					description = "TEE firmware";
++					type = "firmware";
++					arch = "arm64";
++					compression = "none";
++					load = <0xbe000000>;
++					entry = <0xbe000000>;
++
++					tee_blob: blob-ext {
++						filename = "tee.bin";
++					};
++				};
++
+ 				@fdt-SEQ {
+ 					compression = "none";
+ 					description = "NAME";
+@@ -169,7 +182,9 @@
+ 					fdt = "fdt-SEQ";
+ 					firmware = "uboot";
+ #ifndef CONFIG_ARMV8_PSCI
+-					loadables = "atf";
++					loadables = "atf", "tee";
++#else
++					loadables = "tee";
+ #endif
+ 				};
+ 			};
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/u-boot-optee.inc
+++ b/recipes-bsp/u-boot/u-boot-optee.inc
@@ -5,4 +5,8 @@ SRC_URI:append:verdin-imx8mp = "\
     file://dram-banks.cfg \
 "
 
+SRC_URI:append:verdin-imx8mm = "\
+    file://0001-imx8mm-binman-add-tee-node.patch \
+"
+
 IMX_BOOT_CONTAINER_FIRMWARE:append = "tee.bin"

--- a/recipes-security/optee/optee-tdx-verdin-imx8mm.inc
+++ b/recipes-security/optee/optee-tdx-verdin-imx8mm.inc
@@ -1,0 +1,5 @@
+# compatible machine in OP-TEE source code
+OPTEEMACHINE = "imx-mx8mmevk"
+
+# uart base address (to print debug messages)
+UART_BASE_ADDR = "0x30860000"


### PR DESCRIPTION
This adds OP-TEE support for Verdin iMX8MM.

Tested with `optee_example_hello_world`, `optee_example_random`, xtest `test` applications. Also tested fTPM implementation.