### PR TITLE
optee: add support for Verdin iMX8MM (kirkstone)

### DIFF
--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -36,7 +36,10 @@ inherit ${@ 'tdx-tezi-data-partition' if 'teziimg' in d.getVar('IMAGE_FSTYPES') 
 addhandler validate_optee_support
 validate_optee_support[eventmask] = "bb.event.SanityCheck"
 python validate_optee_support() {
-    supported_machines = ['verdin-imx8mp']
+    supported_machines = [
+        'verdin-imx8mp',
+        'verdin-imx8mm',
+    ]
     machine = e.data.getVar('MACHINE')
     if machine not in supported_machines:
         bb.fatal("OP-TEE is currently not supported on '%s' machine!" % machine)

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -9,6 +9,7 @@ TEE might be a good solution to store and manage secrets (e.g. encryption keys) 
 This layer provides support for running OP-TEE on the following SoMs:
 
 - Verdin iMX8MP
+- Verdin iMX8MM
 
 ## Enabling OP-TEE
 

--- a/recipes-security/optee/optee-tdx-verdin-imx8mm.inc
+++ b/recipes-security/optee/optee-tdx-verdin-imx8mm.inc
@@ -1,0 +1,5 @@
+# compatible machine in OP-TEE source code
+OPTEEMACHINE = "imx-mx8mmevk"
+
+# uart base address (to print debug messages)
+UART_BASE_ADDR = "0x30860000"


### PR DESCRIPTION
This adds OP-TEE support for Verdin iMX8MM.

Tested with `optee_example_hello_world`, `optee_example_random` and `xtest` applications. Also tested the fTPM implementation.