### PR TITLE
Add OP-TEE/fTPM support to Verdin AM62 (scarthgap)

### DIFF
--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -1,6 +1,9 @@
 # enable OP-TEE support
 TDX_OPTEE_ENABLE = "1"
 
+# disable OP-TEE on R5 firmware for K3 based platforms
+TDX_OPTEE_ENABLE:verdin-am62-k3r5 = "0"
+
 # required by some vendor BSPs
 MACHINE_FEATURES:append = " optee"
 
@@ -39,7 +42,12 @@ python validate_optee_support() {
     supported_machines = [
         'verdin-imx8mp',
         'verdin-imx8mm',
+        'verdin-am62',
     ]
+
+    if e.data.getVar('TDX_OPTEE_ENABLE') == '0':
+        return
+
     machine = e.data.getVar('MACHINE')
     if machine not in supported_machines:
         bb.fatal("OP-TEE is currently not supported on '%s' machine!" % machine)

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -10,6 +10,7 @@ This layer provides support for running OP-TEE on the following SoMs:
 
 - Verdin iMX8MP
 - Verdin iMX8MM
+- Verdin AM62
 
 ## Enabling OP-TEE
 
@@ -33,7 +34,7 @@ Trusted Platform Modules (TPMs) are designed to enhance system security by perfo
 
 An fTPM (Firmware-based Trusted Platform Module) is a type of TPM that operates within firmware, as opposed to being a discrete hardware chip. While it offers similar functionality, it runs inside a Trusted Execution Environment (TEE), such as OP-TEE.
 
-The [fTPM implementation](https://github.com/microsoft/ms-tpm-20-ref) integrated into this layer uses the secure storage API provided by OP-TEE. This secure storage currently saves data in `/data/tee/`, where persistent information such as cryptographic keys and other general-purpose data is securely stored. All stored data is encrypted using a Hardware Unique Key (HUK), which is supplied by the CAAM driver on i.MX platforms.
+The [fTPM implementation](https://github.com/microsoft/ms-tpm-20-ref) integrated into this layer uses the secure storage API provided by OP-TEE. This secure storage currently saves data in `/data/tee/`, where persistent information such as cryptographic keys and other general-purpose data is securely stored. All stored data is encrypted using a Hardware Unique Key (HUK), which is supplied by the CAAM driver on i.MX platforms and the DMSC subsystem on K3 based devices (e.g. AM6X).
 
 For further details on how secure storage works in OP-TEE, refer to the [OP-TEE documentation](https://optee.readthedocs.io/en/latest/architecture/secure_storage.html).
 

--- a/recipes-security/optee/files/tee-supplicant.rules
+++ b/recipes-security/optee/files/tee-supplicant.rules
@@ -1,0 +1,2 @@
+# Start an instance of tee-supplicant service if a /dev/teepriv[0-9]* device is detected
+KERNEL=="teepriv[0-9]*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="tee-supplicant@%k.service"

--- a/recipes-security/optee/optee-client_%.bbappend
+++ b/recipes-security/optee/optee-client_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://tee-supplicant.rules \
+"
+
+# The optee-client upstream recipe installs a tee-supplicant template unit
+# that requires an udev rule to start the tee supplicant daemon automatically
+do_install:append() {
+    if [ -e "${D}${systemd_system_unitdir}/tee-supplicant@.service" ]; then
+        install -d ${D}${nonarch_base_libdir}/udev/rules.d/
+        install -m 755 ${WORKDIR}/tee-supplicant.rules ${D}${nonarch_base_libdir}/udev/rules.d/
+    fi
+}

--- a/recipes-security/optee/optee-tdx-verdin-am62.inc
+++ b/recipes-security/optee/optee-tdx-verdin-am62.inc
@@ -1,0 +1,1 @@
+# no additional configuration variables are required for Verdin AM62


### PR DESCRIPTION
Build and runtime tested on BSP (scarhgap and kirkstone branches, tdx-reference-minimal-image image) and Torizon OS (scarthgap branch, torizon-upstream distro, torizon-minimal image).