### PR TITLE
u-boot: add missing patch for upstream modules (kirkstone only)

### DIFF
--- a/recipes-bsp/u-boot/files/0010-toradex-show-message-if-CLI-access-allowed-upstream.patch
+++ b/recipes-bsp/u-boot/files/0010-toradex-show-message-if-CLI-access-allowed-upstream.patch
@@ -1,0 +1,34 @@
+From bdc6adbd1a2990a993a7c39736f647a8d96c3096 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 10 Oct 2024 00:39:52 -0300
+Subject: [PATCH 10/10] toradex: show message if CLI access allowed
+ (upstream)
+
+Before, a message was shown only when the device was closed and the CLI
+access was disabled by the CLI protection feature. Now we show a message
+also when the device is open which is helpful when someone wants to
+ensure the protection is compiled in without having to close the device.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ common/main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/main.c b/common/main.c
+index 465febaf628..54ee96886a7 100644
+--- a/common/main.c
++++ b/common/main.c
+@@ -63,7 +63,7 @@ void main_loop(void)
+ 
+ 	s = bootdelay_process();
+ #if CONFIG_IS_ENABLED(TDX_CLI_PROTECTION)
+-	if (!tdx_cli_access_enabled())
++	if (!tdx_cli_access_enabled(1))
+ 		tdx_secure_boot_cmd(s);		/* no return */
+ #endif
+ 	if (cli_process_fdt(&s))
+-- 
+2.34.1
+


### PR DESCRIPTION
Commit 9459b6fe70cac8570b0fd879c422c49692674c3e (u-boot: add patches to show message when CLI access is allowed) missed the patch for upstream modules which is being fixed here.

Detected by CI.
