### PR TITLE
Allow tdx-encrypted to be used with Torizon (plus improvements)

### DIFF
--- a/classes/tdx-encrypted.bbclass
+++ b/classes/tdx-encrypted.bbclass
@@ -1,5 +1,5 @@
-# Enable encryption support
-TDX_ENC_ENABLE = "1"
+# override for conditional assignment
+DISTROOVERRIDES .= ":tdx-encrypted"
 
 # Encryption key backend
 # This variable defines how the encryption key is managed

--- a/classes/tdx-encrypted.bbclass
+++ b/classes/tdx-encrypted.bbclass
@@ -41,6 +41,13 @@ TDX_ENC_STORAGE_RESERVE ?= "0"
 # Defines where the encrypted storage will be mounted
 TDX_ENC_STORAGE_MOUNTPOINT ?= "/run/encdata"
 
+# Extra arguments passed to "mkfs" when creating the filesystem on top
+# of the encrypted storage
+TDX_ENC_STORAGE_MKFS_ARGS ?= ""
+
+# Extra arguments passed to "mount" when mounting the encrypted storage
+TDX_ENC_STORAGE_MOUNT_ARGS ?= ""
+
 # Enables preservation of existing data on encrypted device
 TDX_ENC_PRESERVE_DATA ?= "0"
 

--- a/classes/tdx-signed-dmverity.bbclass
+++ b/classes/tdx-signed-dmverity.bbclass
@@ -1,5 +1,5 @@
 # add the class name in the overrides for conditional assignment
-DISTROOVERRIDES:append = ":tdx-signed-dmverity"
+DISTROOVERRIDES .= ":tdx-signed-dmverity"
 
 # a ramdisk is required to check the root hash of the verity image
 INITRAMFS_IMAGE ?= "tdx-reference-ramdisk-image"

--- a/classes/tdx-signed.bbclass
+++ b/classes/tdx-signed.bbclass
@@ -1,5 +1,5 @@
 # globally enable signed images
-DISTROOVERRIDES:append = ":tdx-signed"
+DISTROOVERRIDES .= ":tdx-signed"
 
 # FIT image configuration
 require tdx-signed-fit-image.inc

--- a/classes/tdx-tezi-data-partition.bbclass
+++ b/classes/tdx-tezi-data-partition.bbclass
@@ -1,5 +1,5 @@
 # override for conditional assignment
-DISTROOVERRIDES:append = ":tdx-tezi-data-partition"
+DISTROOVERRIDES .= ":tdx-tezi-data-partition"
 
 # data partition filesystem type
 # supported values: ext2, ext3, ext4, fat, ubifs

--- a/classes/tdx-tezi-data-partition.bbclass
+++ b/classes/tdx-tezi-data-partition.bbclass
@@ -9,8 +9,18 @@ TDX_TEZI_DATA_PARTITION_TYPE ?= "ext4"
 # data partition label
 TDX_TEZI_DATA_PARTITION_LABEL ?= "DATA"
 
-# automount data partition at boot time
-TDX_TEZI_DATA_PARTITION_AUTOMOUNT ?= "1"
+# automount data partition at boot time; possible values:
+#  "-1": do not change fstab
+#   "0": add entry to fstab with the noauto option
+#   "1": add entry to fstab with the auto option
+TDX_TEZI_DATA_PARTITION_AUTOMOUNT ?= "${TDX_TEZI_DATA_PARTITION_AUTOMOUNT_DEFAULT}"
+
+# define the default value of above variable based on tdx-encrypted being
+# in use or not; notice TDX_TEZI_DATA_PARTITION_AUTOMOUNT_DEFAULT is for
+# internal usage of the present class and it should not be modified by
+# users (who should only care about TDX_TEZI_DATA_PARTITION_AUTOMOUNT)
+TDX_TEZI_DATA_PARTITION_AUTOMOUNT_DEFAULT = "1"
+TDX_TEZI_DATA_PARTITION_AUTOMOUNT_DEFAULT:tdx-encrypted = "-1"
 
 # data partition mount point
 TDX_TEZI_DATA_PARTITION_MOUNTPOINT ?= "/data"

--- a/docs/README-data-partition.md
+++ b/docs/README-data-partition.md
@@ -21,10 +21,21 @@ Additional variables can be used to customize the behavior of this feature:
 
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
-| TDX_TEZI_DATA_PARTITION_TYPE | Data partition filesystem type. Supported values are `ext2`, `ext3`, `ext4`, `fat` and `ubifs`. The supported values are limited to what Toradex Easy Installer supports | `ext4` |
-| TDX_TEZI_DATA_PARTITION_LABEL | Label that will be used to format and mount the data partition | `DATA` |
-| TDX_TEZI_DATA_PARTITION_AUTOMOUNT | Set to `1` to automatically mount the data partition at boot time, or `0` to disable automouting the partition | `1` |
-| TDX_TEZI_DATA_PARTITION_MOUNTPOINT | Directory where the data partition should be mounted | `/data` |
-| TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS | Flags used to mount the data partition. See the `mount` man page for more information on the available mount flags | `rw,nosuid,nodev,noatime, errors=remount-ro` |
+| `TDX_TEZI_DATA_PARTITION_TYPE` | Data partition filesystem type. Supported values are `ext2`, `ext3`, `ext4`, `fat` and `ubifs`. The supported values are limited to what Toradex Easy Installer supports | `ext4` |
+| `TDX_TEZI_DATA_PARTITION_LABEL` | Label that will be used to format and mount the data partition | `DATA` |
+| `TDX_TEZI_DATA_PARTITION_AUTOMOUNT` | Set to `1` to automatically mount the data partition at boot time, or `0` to disable automouting the partition; when set to `-1` the partition won't even be listed in fstab (it should be mounted by other means) | `-1` if class `tdx-encrypted` is in use or `1` otherwise |
+| `TDX_TEZI_DATA_PARTITION_MOUNTPOINT` | Directory where the data partition should be mounted | `/data` |
+| `TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS` | Flags used to mount the data partition. See the `mount` man page for more information on the available mount flags | `rw,nosuid,nodev,noatime, errors=remount-ro` |
 
 Additional variables from the `image_type_tezi` class in the `meta-toradex-bsp-common` layer can be used to customize the creation of the data partition. Please see the [source code of this class](https://git.toradex.com/cgit/meta-toradex-bsp-common.git/tree/classes/image_type_tezi.bbclass?h=kirkstone-6.x.y#n37) for more information.
+
+## Encrypting the data partition
+
+The default value of `TDX_TEZI_DATA_PARTITION_AUTOMOUNT` assumes the data partition is going to be encrypted when the class `tdx-encrypted` is also used; this is a common situation but not necessarily true and if not true one must set that variable appropriately for their use case.
+
+When the said assumption is true though, having an encrypted data partition would be achieved by setting (in your `local.conf`, for example):
+
+```
+INHERIT += "tdx-tezi-data-partition tdx-encrypted"
+TDX_ENC_STORAGE_LOCATION = "/dev/<block-device-for-data-partition>"
+```

--- a/docs/README-encryption.md
+++ b/docs/README-encryption.md
@@ -63,19 +63,24 @@ TDX_ENC_KEY_BACKEND:forcevariable = "tpm"
 
 Make sure to use the `forcevariable` override, so your configuration takes precedence over the default one.
 
-A few additional variables are available to customize the behavior of the data-at-rest encryption feature. Here is the complete list:
+A few additional variables are available to customize the behavior of the data-at-rest encryption feature. Here is list of the most important ones (for the full list refer to `tdx-encrypted.bbclass`):
 
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
-| TDX_ENC_KEY_BACKEND | Backend used to manage the encryption key. Allowed values: `caam`, `tpm` or `cleartext`. If configured with `caam`, it will use Trusted Keys backed by the CAAM device (available on NXP iMX-based SoMs). If configured with `tpm`, it will use Trusted Keys backed by a TPM device (availability depends on the hardware). If configured with `cleartext`, the encryption key will be stored in clear text in the file system (use `cleartext` only for testing purposes!) | `caam` on iMX based SoMs, empty otherwise |
-| TDX_ENC_KEY_LOCATION | Location to store the encryption key blob. Allowed values: `filesystem` or `partition`. If configured with `filesystem`, the encryption key blob will be stored as a file in the filesystem (location defined by the `TDX_ENC_KEY_DIR` variable. If configured with `partition`, the encryption key blob will be stored in a block of the disk outside the dm-crypt partition (useful if the rootfs filesystem is read-only) | `filesystem` |
-| TDX_ENC_KEY_DIR | Directory to store the encryption key blob | `/var/local/private/.keys` |
-| TDX_ENC_KEY_FILE | File name of the encryption key blob | `tdx-enc-key.blob` |
-| TDX_ENC_STORAGE_LOCATION | Partition to be encrypted (e.g. `/dev/sdb1`) | Empty |
-| TDX_ENC_STORAGE_RESERVE | Number of blocks to reserve from the partition to be encrypted. Each block is 512-byte in size. Might be useful in case one needs a storage location to save data in raw mode, outside the dm-drypt partition. If `TDX_ENC_KEY_LOCATION` is set to `partition`, then the first reserved block is used to store the encryption key blob. | `0` |
-| TDX_ENC_STORAGE_MOUNTPOINT | Directory to mount the encrypted partition | `/run/encdata` |
+| `TDX_ENC_KEY_BACKEND` | Backend used to manage the encryption key. Allowed values: `caam`, `tpm` or `cleartext`. If configured with `caam`, it will use Trusted Keys backed by the CAAM device (available on NXP iMX-based SoMs). If configured with `tpm`, it will use Trusted Keys backed by a TPM device (availability depends on the hardware). If configured with `cleartext`, the encryption key will be stored in clear text in the file system (use `cleartext` only for testing purposes!) | `caam` on iMX based SoMs, empty otherwise |
+| `TDX_ENC_KEY_LOCATION` | Location to store the encryption key blob. Allowed values: `filesystem` or `partition`. If configured with `filesystem`, the encryption key blob will be stored as a file in the filesystem (location defined by the `TDX_ENC_KEY_DIR` variable. If configured with `partition`, the encryption key blob will be stored in a block of the disk outside the dm-crypt partition (useful if the rootfs filesystem is read-only) | `filesystem` |
+| `TDX_ENC_KEY_DIR` | Directory to store the encryption key blob | `/var/local/private/.keys` |
+| `TDX_ENC_KEY_FILE` | File name of the encryption key blob | `tdx-enc-key.blob` |
+| `TDX_ENC_STORAGE_LOCATION` | Partition to be encrypted (e.g. `/dev/sdb1`) | Empty |
+| `TDX_ENC_STORAGE_RESERVE` | Number of blocks to reserve from the partition to be encrypted. Each block is 512-byte in size. Might be useful in case one needs a storage location to save data in raw mode, outside the dm-drypt partition. If `TDX_ENC_KEY_LOCATION` is set to `partition`, then the first reserved block is used to store the encryption key blob. | `0` |
+| `TDX_ENC_STORAGE_MOUNTPOINT` | Directory to mount the encrypted partition | `/run/encdata` |
+| `TDX_ENC_STORAGE_MKFS_ARGS` | Extra arguments to be passed to `mkfs.ext4` when creating the filesystem on the encrypted storage | Empty |
+| `TDX_ENC_STORAGE_MOUNT_ARGS` | Extra arguments to be passed to `mount` when mounting the filesystem on the encrypted storage | Empty |
 
-IMPORTANT: The script that mounts the encrypted partition runs early in the boot process, where not necessarily udev has run/settled. For that reason, it is recommended to use the name of the partition as assigned by the kernel (e.g. `/dev/sdb1`). If one wants to set a name that relies on udev rules then one must review the systemd dependencies of the service to ensure the name is available.
+IMPORTANT:
+
+- The service that mounts the encrypted partition (`tdx-enc-handler.service`) runs early in the boot process, where not necessarily udev has run/settled. For that reason, it is recommended to use the name of the partition as assigned by the kernel (e.g. `/dev/sdb1`). If one wants to set a name that relies on udev rules then one must review the systemd dependencies of the service to ensure the name is available.
+- Similarly, the location where the encrypted key blob is stored must also be available to the to service; currently the service definition includes dependencies to ensure `/var` is available so that the default configuration works; if storing the key blob outside of `/var` one must review the service definition.
 
 ## Notes on using CAAM
 

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,6 +1,27 @@
 do_install:append:tdx-tezi-data-partition() {
-    AUTO=$([ "${TDX_TEZI_DATA_PARTITION_AUTOMOUNT}" = "1" ] && echo "auto" || echo "noauto")
-    echo "LABEL=DATA  ${TDX_TEZI_DATA_PARTITION_MOUNTPOINT}  auto  ${TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS},${AUTO}  0  0" >> ${D}/etc/fstab
+    local auto_option=""
+    local modify_fstab="0"
+
+    case "${TDX_TEZI_DATA_PARTITION_AUTOMOUNT}" in
+        -1)
+                modify_fstab="0"
+                ;;
+        0)
+                auto_option="noauto"
+                modify_fstab="1"
+                ;;
+        1)
+                auto_option="auto"
+                modify_fstab="1"
+                ;;
+        *)
+                bbfatal "Variable TDX_TEZI_DATA_PARTITION_AUTOMOUNT is set to an unknown value (${TDX_TEZI_DATA_PARTITION_AUTOMOUNT})."
+                ;;
+    esac
+
+    if [ "${modify_fstab}" = "1" ]; then
+        echo "LABEL=${TDX_TEZI_DATA_PARTITION_LABEL}  ${TDX_TEZI_DATA_PARTITION_MOUNTPOINT}  auto  ${TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS},${auto_option}  0  0" >> ${D}/etc/fstab
+    fi
 }
 
 pkg_postinst:${PN}:append:tdx-tezi-data-partition() {

--- a/recipes-core/busybox/busybox_%.bbappend
+++ b/recipes-core/busybox/busybox_%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI:append = "\
-    ${@oe.utils.conditional('TDX_ENC_ENABLE', '1', 'file://tdx-enc-handler-requirements.cfg', '', d)} \
+SRC_URI:append:tdx-encrypted = "\
+    file://tdx-enc-handler-requirements.cfg \
 "

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc-handler.service
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc-handler.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Encryption handler for Toradex modules
 DefaultDependencies=no
-Wants=tmp.mount
 Before=local-fs.target
 After=systemd-remount-fs.service
+RequiresMountsFor=/tmp /var
 
 [Service]
 Type=oneshot

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
@@ -30,10 +30,16 @@ TDX_ENC_STORAGE_NUM_BLOCKS=""
 # directory to mount the encrypted storage
 TDX_ENC_STORAGE_MOUNTPOINT="@@TDX_ENC_STORAGE_MOUNTPOINT@@"
 
+# extra arguments to mkfs; used when running mkfs on the encrypted storage
+TDX_ENC_STORAGE_MKFS_ARGS="@@TDX_ENC_STORAGE_MKFS_ARGS@@"
+
+# extra arguments to mount; used when mounting the fs stored on the encrypted storage
+TDX_ENC_STORAGE_MOUNT_ARGS="@@TDX_ENC_STORAGE_MOUNT_ARGS@@"
+
 # dm-crypt device to be created
 TDX_ENC_DM_DEVICE="encdata"
 
-# Flag to enable preservation of data on partition before encryption
+# flag to enable preservation of data on partition before encryption
 TDX_ENC_PRESERVE_DATA=@@TDX_ENC_PRESERVE_DATA@@
 
 # storage location of data backup file (if needed)
@@ -304,12 +310,12 @@ tdx_enc_partition_mount() {
     # format encrypted partition (if not formatted)
     if ! blkid /dev/mapper/"${TDX_ENC_DM_DEVICE}"; then
         tdx_enc_log "Formatting encrypted partition with ext4..."
-        mkfs.ext4 -q /dev/mapper/"${TDX_ENC_DM_DEVICE}"
+        mkfs.ext4 -q /dev/mapper/"${TDX_ENC_DM_DEVICE}" ${TDX_ENC_STORAGE_MKFS_ARGS}
     fi
 
     # mount encrypted partition
     mkdir -p "${TDX_ENC_STORAGE_MOUNTPOINT}"
-    if ! mount -t ext4 /dev/mapper/"${TDX_ENC_DM_DEVICE}" "${TDX_ENC_STORAGE_MOUNTPOINT}"; then
+    if ! mount -t ext4 /dev/mapper/"${TDX_ENC_DM_DEVICE}" "${TDX_ENC_STORAGE_MOUNTPOINT}" ${TDX_ENC_STORAGE_MOUNT_ARGS}; then
         tdx_enc_exit_error "Could not mount encrypted partition!"
     fi
 }

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
@@ -343,8 +343,10 @@ tdx_enc_clear_keys_keyring() {
 
 # umount partition
 tdx_enc_partition_umount() {
-    tdx_enc_log "Unmounting dm-crypt partition..."
-    umount "${TDX_ENC_STORAGE_MOUNTPOINT}"
+    for mnt in $(lsblk /dev/mapper/"${TDX_ENC_DM_DEVICE}" -n -o MOUNTPOINTS); do
+        tdx_enc_log "Unmounting dm-crypt partition from '${mnt}'..."
+        umount "${mnt}"
+    done
 }
 
 # remove dm-crypt partition

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
@@ -37,6 +37,8 @@ do_install() {
     sed -i 's|@@TDX_ENC_STORAGE_LOCATION@@|${TDX_ENC_STORAGE_LOCATION}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_STORAGE_RESERVE@@|${TDX_ENC_STORAGE_RESERVE}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_STORAGE_MOUNTPOINT@@|${TDX_ENC_STORAGE_MOUNTPOINT}|g' ${D}${sbindir}/tdx-enc.sh
+    sed -i 's|@@TDX_ENC_STORAGE_MKFS_ARGS@@|${TDX_ENC_STORAGE_MKFS_ARGS}|g' ${D}${sbindir}/tdx-enc.sh
+    sed -i 's|@@TDX_ENC_STORAGE_MOUNT_ARGS@@|${TDX_ENC_STORAGE_MOUNT_ARGS}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_KEY_DIR@@|${TDX_ENC_KEY_DIR}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_PRESERVE_DATA@@|${TDX_ENC_PRESERVE_DATA}|g' ${D}${sbindir}/tdx-enc.sh
     sed -i 's|@@TDX_ENC_BACKUP_STORAGE_PCT@@|${TDX_ENC_BACKUP_STORAGE_PCT}|g' ${D}${sbindir}/tdx-enc.sh

--- a/recipes-kernel/linux/linux-sec-features.inc
+++ b/recipes-kernel/linux/linux-sec-features.inc
@@ -4,7 +4,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 require ${@ 'linux-dm-verity.inc' if 'tdx-signed-dmverity' in d.getVar('OVERRIDES').split(':') else ''}
 
 # dm-crypt support
-require ${@ 'linux-dm-crypt.inc' if d.getVar('TDX_ENC_ENABLE') == '1' else ''}
+require ${@ 'linux-dm-crypt.inc' if 'tdx-encrypted' in d.getVar('OVERRIDES').split(':') else ''}
 
 # op-tee support
 require ${@ 'linux-optee.inc' if d.getVar('TDX_OPTEE_ENABLE') == '1' else ''}


### PR DESCRIPTION
This should fix the problems with using `tdx-encrypted` with Torizon OS - this is achieved by the first two commits.

The other commits introduce a few other improvements (and a bugfix). Please refer to the commit messages for details.
