### PR TITLE
Add support for using RPMB as a secure storage device

### DIFF
--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -11,6 +11,28 @@ MACHINE_FEATURES:append = " optee"
 TDX_OPTEE_FTPM ?= "0"
 MACHINE_FEATURES:append = " ${@oe.utils.conditional('TDX_OPTEE_FTPM', '1', 'optee-ftpm', '', d)}"
 
+# enable support for using the eMMC RPMB partition as a secure storage device
+TDX_OPTEE_FS_RPMB ?= "0"
+
+# eMMC RPMB partition device node ID (i.e. /dev/mmcblk<id>rpmb)
+TDX_OPTEE_FS_RPMB_DEV_ID ??= "0"
+
+# RPMB secure storage operation mode
+#    "development": The RPMB partition is emulated in software by tee-supplicant.
+#                   Be aware that the emulation is done in memory, so the
+#                   contents of the storage is lost after a reboot or when the
+#                   tee-supplicant daemon is restarted.
+#    "factory":     The eMMC RPMB partition is used, and OP-TEE is configured
+#                   to program the RPMB key. The RPMB key is derived from the
+#                   SoC's Hardware Unique Key (HUK). This mode is intended for
+#                   secure factory provisioning environments, and it should
+#                   never be used outside of a trusted, secure factory setup.
+#    "production":  The eMMC RPMB partition is used, and it is assumed that the
+#                   RPMB key has already been programmed into the RPMB partition.
+#                   This mode is designed for production environments, where
+#                   secure storage operations rely on a pre-provisioned RPMB key.
+TDX_OPTEE_FS_RPMB_MODE ?= "development"
+
 # enable OP-TEE debug messages
 TDX_OPTEE_DEBUG ?= "0"
 
@@ -21,6 +43,7 @@ TDX_OPTEE_INSTALL_TESTS ?= "0"
 TDX_OPTEE_PACKAGES_TESTS = "\
     optee-test \
     optee-examples \
+    mmc-utils \
 "
 
 # extra packages for OP-TEE support
@@ -51,4 +74,9 @@ python validate_optee_support() {
     machine = e.data.getVar('MACHINE')
     if machine not in supported_machines:
         bb.fatal("OP-TEE is currently not supported on '%s' machine!" % machine)
+
+    if e.data.getVar('TDX_OPTEE_FS_RPMB') == '1' and e.data.getVar('TDX_OPTEE_FS_RPMB_MODE') == 'factory':
+        bb.warn("The factory mode for OP-TEE RPMB support is intended for " \
+                "secure factory provisioning environments, and it should " \
+                "never be used outside of a trusted, secure factory setup!")
 }

--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -54,9 +54,10 @@ IMAGE_INSTALL:append = "\
     ${@oe.utils.conditional('TDX_OPTEE_INSTALL_TESTS', '1', '${TDX_OPTEE_PACKAGES_TESTS}', '', d)} \
 "
 
-# enable data partition if dm-verity and tezi are both enabled
+# enable data partition if dm-verity and tezi are both enabled, and RPMB is not enabled
 inherit ${@ 'tdx-tezi-data-partition' if 'teziimg' in d.getVar('IMAGE_FSTYPES') and \
-            'tdx-signed-dmverity' in d.getVar('OVERRIDES').split(':') else ''}
+            'tdx-signed-dmverity' in d.getVar('OVERRIDES').split(':') and \
+            d.getVar('TDX_OPTEE_FS_RPMB') == '0' else ''}
 
 # validate optee support
 addhandler validate_optee_support

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -26,27 +26,10 @@ A few variables can be used to customize the behavior of this feature:
 | :------- | :---------- | :------------ |
 | TDX_OPTEE_DEBUG | Enable OP-TEE debug messages to the serial console (`1` to enable or `0` to disable) | `0` |
 | TDX_OPTEE_INSTALL_TESTS | Enable the installation of OP-TEE test applications (`1` to enable or `0` to disable) | `0` |
-| TDX_OPTEE_FTPM | Enable support for a firmware TPM (fTPM) implementation running as trusted application in OP-TEE (`1` to enable or `0` to disable). For more information on how an fTPM works, see the next session. | `0` |
-
-## fTPM support in OP-TEE
-
-Trusted Platform Modules (TPMs) are designed to enhance system security by performing cryptographic operations such as key generation, encryption, and digital signing. Their primary role is to provide secure storage for cryptographic keys and ensure system integrity by measuring the software environment during the boot process.
-
-An fTPM (Firmware-based Trusted Platform Module) is a type of TPM that operates within firmware, as opposed to being a discrete hardware chip. While it offers similar functionality, it runs inside a Trusted Execution Environment (TEE), such as OP-TEE.
-
-The [fTPM implementation](https://github.com/microsoft/ms-tpm-20-ref) integrated into this layer uses the secure storage API provided by OP-TEE. This secure storage currently saves data in `/data/tee/`, where persistent information such as cryptographic keys and other general-purpose data is securely stored. All stored data is encrypted using a Hardware Unique Key (HUK), which is supplied by the CAAM driver on i.MX platforms and the DMSC subsystem on K3 based devices (e.g. AM6X).
-
-For further details on how secure storage works in OP-TEE, refer to the [OP-TEE documentation](https://optee.readthedocs.io/en/latest/architecture/secure_storage.html).
-
-It's important to note that an fTPM may not entirely replace the need for a discrete TPM chip, as this depends on the specific use case and the product's threat model. Nevertheless, an fTPM can provide adequate security for certain scenarios, especially when incorporating a hardware TPM chip is impractical.
-
-## Read-write filesystem for OP-TEE
-
-OP-TEE needs a read-write filesystem (by default, it writes to `/data/tee/`). When rootfs signature checking is enabled via the `tdxref-signed` class, the rootfs image will be generated using the `dm-verity` kernel feature, which is read-only.
-
-In this case, to provide a read-write filesystem to OP-TEE, the `tdx-tezi-data-partition` class will be automatically inherited. This class will create an additional partition in the eMMC and mount it by default at `/data`. For more information on how this class works, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).
-
-In case your rootfs is read-only and you are not using a Toradex Easy Installer image, make sure the `/data` directory is mounted at a read-write partition, or OP-TEE will not work properly.
+| TDX_OPTEE_FS_RPMB | Enable support for using the eMMC RPMB partition as a secure storage device (`1` to enable or `0` to disable) | `0` |
+| TDX_OPTEE_FS_RPMB_DEV_ID | Configure the eMMC RPMB partition device node. For example, if configured with `2`, the TEE supplicant will use `/dev/mmcblk2rpmb` to communicate with to the RPMB partition | `0` |
+| TDX_OPTEE_FS_RPMB_MODE | RPMB secure storage operation mode. Valid options are `development` (to be used during development), `factory` (to enroll the RPMB key in a secure provisioning environment) and `production` (to be used in production). For more information on how to configure this variable, see the session [RPMB support in OP-TEE](/docs/README-optee.md#rpmb-support-in-op-tee) | `development` |
+| TDX_OPTEE_FTPM | Enable support for a firmware TPM (fTPM) implementation running as trusted application in OP-TEE (`1` to enable or `0` to disable). For more information on how an fTPM works, see the session [fTPM support in OP-TEE](/docs/README-optee.md#ftpm-support-in-op-tee) | `0` |
 
 ## Testing OP-TEE
 
@@ -69,3 +52,86 @@ There is also a complete test suite that can be used to validate OP-TEE:
 ```
 
 In case of issues, try enabling debug messages via the `TDX_OPTEE_DEBUG` variable.
+
+## Secure storage for persistent data in OP-TEE
+
+OP-TEE requires a secure storage solution to save persistent data, including cryptographic keys, key materials, and general-purpose data.
+
+There are currently two secure storage implementations in OP-TEE:
+
+- The first one relies on the normal world (REE) file system.
+- The second one makes use of the Replay Protected Memory Block (RPMB) partition of an eMMC device.
+
+When relying on the normal world file system, OP-TEE uses `/data/tee/` as its secure storage location in the Linux file system. All stored data is encrypted using a Hardware Unique Key (HUK), which is supplied by the CAAM driver on i.MX platforms and the DMSC subsystem on K3-based devices (e.g., AM6X).
+
+To be able to write and persist data, OP-TEE needs a read-write filesystem mounted at `/data`. When rootfs signature checking is enabled via the `tdxref-signed` class, the rootfs image will be generated using the `dm-verity` kernel feature, which is read-only. In this case, to provide a read-write filesystem to OP-TEE, the `tdx-tezi-data-partition` class will be automatically inherited. This class will create an additional partition in the eMMC and mount it by default at `/data`. For more information on how this class works, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).
+
+If your rootfs is read-only and you are not using a Toradex Easy Installer image, ensure that the `/data` directory is mounted on a writable partition. Failing to do so will prevent OP-TEE from functioning properly (in case you are relying on the normal world file system for secure storage).
+
+When using RPMB (Replay Protected Memory Block) as the secure storage device, a writable `/data` partition is not required. The RPMB partition is used instead for secure storage. For more information on RPMB usage with OP-TEE, see the section [RPMB support in OP-TEE](/docs/README-optee.md#rpmb-support-in-op-tee).
+
+For further details on how secure storage works in OP-TEE, refer to the [OP-TEE documentation](https://optee.readthedocs.io/en/latest/architecture/secure_storage.html).
+
+## RPMB support in OP-TEE
+
+RPMB (Replay Protected Memory Block) is a dedicated partition available on some flash-based storage devices (eMMC, UFS, NVMe, etc) that makes it possible to store and retrieve data with integrity and authenticity support. It was introduced in eMMC version 4.4, and it is available and ready to be used on most Toradex modules.
+
+When using the RPMB partition, a symmetric key is used to authenticate reads and writes. In a nutshell, here is how it works:
+
+- An authentication key is first programmed to the storage device. This step must occur in a secure environment, typically in a secure factory setup.
+- When writing to the device, the data is hashed and signed with the authentication key, and the storage device will only accept the write operation after checking the signature (this signature is also called message authentication code, or just MAC).
+- When reading from the device, the data is returned together with the MAC. The host can also calculate the MAC and compare it with the one received to make sure the message is authentic.
+
+OP-TEE can use the RPMB partition as a secure storage solution instead of relying on the Linux filesystem. To enable this feature, set the `TDX_OPTEE_FS_RPMB` variable to `1`.
+
+One significant challenge with RPMB is the requirement to write a private key to the partition before any operations. This key programming can only be done once and must occur in a secure provisioning environment.
+
+To address this, the `TDX_OPTEE_FS_RPMB_MODE` variable is introduced, allowing you to configure the RPMB operation mode. The supported values are: `development`, `factory`, and `production`:
+
+- `development`: The RPMB partition is emulated in software by `tee-supplicant`. Be aware that the emulation is done in memory, so the contents of the storage is lost after a reboot or when the `tee-supplicant` daemon is restarted. Suitable option for development.
+- `factory`: The eMMC RPMB partition is used, and OP-TEE is configured to program the RPMB key, derived from the SoC's Hardware Unique Key (HUK) and other device specific information. This mode is intended for secure factory provisioning environments, and it should never be used outside of a trusted, secure factory setup.
+- `production`: The eMMC RPMB partition is used with the assumption that the RPMB key has already been programmed (enrolled). Designed for production environments where secure storage relies on a pre-provisioned RPMB key.
+
+With this, one could use an OS image configured in `factory` mode during a secure provisioning process, then deploy an OS image configured in `production` mode to devices in the field. However, be aware that alternative RPMB key provisioning methods exist, and the approach should align with your threat model.
+
+Another important aspect is how the key generation works. Because OP-TEE derives the RPMB authentication key from the SoC's HUK, if the RPMB key is provisioned while the device is in an "open" state (secure boot disabled), it becomes inaccessible once secure boot is enabled, because the HUK changes when the device transitions to a "closed" state.
+
+To prevent this issue, OP-TEE includes a software hook, `plat_rpmb_key_is_ready()`, which platforms can use to enforce a security logic. For example, on i.MX-based devices, the RPMB key cannot be written unless secure boot is enabled. This behavior can be modified by overriding the `plat_rpmb_key_is_ready()` function in the `core/drivers/imx_snvs.c` file of the OP-TEE OS source code.
+
+To test RPMB functionality, use OP-TEE's test tools to write to the storage and verify if the RPMB write counter increases. Note that this test will not work in development mode since the RPMB partition is emulated in memory.
+
+```
+# mmc rpmb read-counter /dev/mmcblk*rpmb
+# optee_example_secure_storage
+# mmc rpmb read-counter /dev/mmcblk*rpmb
+```
+
+## fTPM support in OP-TEE
+
+Trusted Platform Modules (TPMs) are designed to enhance system security by performing cryptographic operations such as key generation, encryption, and digital signing. Their primary role is to provide secure storage for cryptographic keys and ensure system integrity by measuring the software environment during the boot process.
+
+An fTPM (Firmware-based Trusted Platform Module) is a type of TPM that operates within firmware, as opposed to being a discrete hardware chip. While it offers similar functionality, it runs inside a Trusted Execution Environment (TEE), such as OP-TEE.
+
+Using this layer, fTPM can be enabled by adding the following line to an OE configuration file (e.g. `local.conf`):
+
+```
+TDX_OPTEE_FTPM = "1"
+```
+
+When fTPM is enabled, you should have a TPM device at `/dev`:
+
+```
+# ls -l /dev/tpm*
+```
+
+And the TPM2 tools can be used to test it:
+
+```
+# tpm2_getrandom 32 | hexdump -C
+```
+
+It's important to note that an fTPM may not entirely replace the need for a discrete TPM chip, as this depends on the specific use case and the product's threat model. Nevertheless, an fTPM can provide adequate security for certain scenarios, especially when incorporating a hardware TPM chip is impractical.
+
+## Important note
+
+This layer provides the foundational infrastructure to enable OP-TEE functionality on supported hardware platforms. However, it is important to note that this layer is not designed to serve as a comprehensive, ready-to-deploy security solution for all use cases. Always make sure to review the implementation and adapt it to your own needs.

--- a/recipes-security/optee/include/optee-tdx-verdin-am62.inc
+++ b/recipes-security/optee/include/optee-tdx-verdin-am62.inc
@@ -1,1 +1,2 @@
-# no additional configuration variables are required for Verdin AM62
+# eMMC RPMB partition device node ID
+TDX_OPTEE_FS_RPMB_DEV_ID ?= "0"

--- a/recipes-security/optee/include/optee-tdx-verdin-imx8mm.inc
+++ b/recipes-security/optee/include/optee-tdx-verdin-imx8mm.inc
@@ -3,3 +3,6 @@ OPTEEMACHINE = "imx-mx8mmevk"
 
 # uart base address (to print debug messages)
 UART_BASE_ADDR = "0x30860000"
+
+# eMMC RPMB partition device node ID
+TDX_OPTEE_FS_RPMB_DEV_ID ?= "0"

--- a/recipes-security/optee/include/optee-tdx-verdin-imx8mp.inc
+++ b/recipes-security/optee/include/optee-tdx-verdin-imx8mp.inc
@@ -3,3 +3,6 @@ OPTEEMACHINE = "imx-mx8mpevk"
 
 # uart base address (to print debug messages)
 UART_BASE_ADDR = "0x30880000"
+
+# eMMC RPMB partition device node ID
+TDX_OPTEE_FS_RPMB_DEV_ID ?= "2"

--- a/recipes-security/optee/optee-client_%.bbappend
+++ b/recipes-security/optee/optee-client_%.bbappend
@@ -13,5 +13,7 @@ do_install:append() {
     fi
 }
 
+require ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB', '1', 'optee-fs-rpmb.inc', '', d)}
+
 # make sure the recipe is selected by the current machine
 COMPATIBLE_MACHINE = "${MACHINE}"

--- a/recipes-security/optee/optee-client_%.bbappend
+++ b/recipes-security/optee/optee-client_%.bbappend
@@ -13,6 +13,10 @@ do_install:append() {
     fi
 }
 
+EXTRA_OEMAKE:append = "\
+    ${@oe.utils.conditional('TDX_OPTEE_DEBUG', '1', 'CFG_TEE_SUPP_LOG_LEVEL=3', '', d)} \
+"
+
 require ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB', '1', 'optee-fs-rpmb.inc', '', d)}
 
 # make sure the recipe is selected by the current machine

--- a/recipes-security/optee/optee-fs-rpmb.inc
+++ b/recipes-security/optee/optee-fs-rpmb.inc
@@ -1,0 +1,43 @@
+# additional build flags for RPMB support in OP-TEE OS
+EXTRA_OEMAKE:append:pn-optee-os = "\
+    CFG_RPMB_FS=y \
+    CFG_REE_FS=n \
+    CFG_RPMB_FS_DEV_ID=${TDX_OPTEE_FS_RPMB_DEV_ID} \
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'development', 'CFG_RPMB_WRITE_KEY=y', '', d)} \
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'factory', 'CFG_RPMB_WRITE_KEY=y CFG_RPMB_RESET_FAT=y', '', d)} \
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'production', '', '', d)} \
+"
+
+# additional build flags for RPMB support in upstream OP-TEE client (CMake based)
+OPTEE_CLIENT_RPMB_CMAKE_OPTS = "\
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'development', '-DRPMB_EMU=ON', '', d)} \
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'factory', '-DRPMB_EMU=OFF', '', d)} \
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'production', '-DRPMB_EMU=OFF', '', d)} \
+"
+OPTEE_CLIENT_RPMB_CMAKE_OPTS:imx-generic-bsp = ""
+EXTRA_OECMAKE:append:pn-optee-client = "\
+    ${OPTEE_CLIENT_RPMB_CMAKE_OPTS} \
+"
+
+# additional build flags for RPMB support in NXP downstream OP-TEE client (Makefile based)
+OPTEE_CLIENT_RPMB_MAKE_OPTS = ""
+OPTEE_CLIENT_RPMB_MAKE_OPTS:imx-generic-bsp = "\
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'development', 'RPMB_EMU=1', '', d)} \
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'factory', 'RPMB_EMU=0', '', d)} \
+    ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB_MODE', 'production', 'RPMB_EMU=0', '', d)} \
+"
+EXTRA_OEMAKE:append:pn-optee-client = "\
+    ${OPTEE_CLIENT_RPMB_MAKE_OPTS} \
+"
+
+# The plat_rpmb_key_is_ready() function in OP-TEE is a platform-specific hook that
+# indicates whether the RPMB key is ready to be programmed and used. On i.MX platforms,
+# this function is implemented to prevent the use of RPMB if the device is not in a
+# closed state (i.e., secure boot enabled). In development mode, where the RPMB partition
+# is emulated in software, this behavior is unnecessary. Therefore, the function can be
+# disabled to allow RPMB emulation to operate without restrictions.
+do_compile:prepend:pn-optee-os() {
+    if [ ${TDX_OPTEE_FS_RPMB_MODE} = "development" ]; then
+        sed -i 's/plat_rpmb_key_is_ready/_plat_rpmb_key_disabled/g' ${S}/core/drivers/imx_snvs.c
+    fi
+}

--- a/recipes-security/optee/optee-tdx.inc
+++ b/recipes-security/optee/optee-tdx.inc
@@ -17,3 +17,5 @@ EXTRA_OEMAKE:append:pn-optee-os = "\
     CFG_UART_BASE=${UART_BASE_ADDR} \
     ${OPTEE_OS_EXTRA_MACHINE_ARGS} \
 "
+
+require ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB', '1', 'optee-fs-rpmb.inc', '', d)}


### PR DESCRIPTION
Tested on Verdin iMX8MP, Verdin iMX8MM and Verdin AM62.

You can view the documentation changes more clearly here: https://github.com/sergioprado/meta-toradex-security/blob/optee-rpmb/docs/README-optee.md