### PR TITLE
Implementing user encryption hook for tdx-enc-handler

### DIFF
--- a/docs/README-encryption.md
+++ b/docs/README-encryption.md
@@ -92,6 +92,10 @@ Be aware that, if you have a device with a partition encrypted with the test key
 
 To workaround this issue, you can manually remove the key blob, which is by default located at `/var/local/private/.keys/tdx-enc-key.blob`. After removing the key blob and rebooting the device, another key will be generated and the partition will be formatted and encrypted with the new key. As a consequence, you will lose any content on the partition previously encrypted with the test key.
 
+Alternatively, you can provide a script located at `/usr/sbin/encryption_allowed`, which will be used to trigger an `Encryption disabled by the user!` error and exit after initially mounting the partition (this will only occur if the partition has not already been encrypted). This could be used to check the system state, for example reading the SEC_BOOT eFuse (in the case of NXP iMX SoCs) and only enabling encryption once the OTPMK is used, thus avoiding issues when using the initial test key.
+
+NOTE: This user script must be owned and only writable by `root` (example Linux permission of 0755).
+
 ## Notes on using a TPM
 
 Before enabling the TPM backend, you need to make sure there is a TPM device available in the hardware and configured in the operating system. This usually involves enabling the device driver in the Linux kernel and adding a node in the device tree. Be aware that providing access to a TPM device is out of scope in this layer.

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
@@ -260,15 +260,31 @@ tdx_enc_key_gen_tpm() {
                               "load \$(cat ${TDX_ENC_KEY_FULLPATH})"
 }
 
-# backup original data in partition (if not encrypted)
-tdx_enc_backup_data() {
-    if [ ${TDX_ENC_PRESERVE_DATA} -ne 1 ]; then
-        tdx_enc_log "Data preservation is not enabled"
-        return 0
+# initially mount the partition if possible
+tdx_enc_pre_mount() {
+    tdx_enc_log "Attempting partition pre-mount"
+
+    if source=$(findmnt -no SOURCE "${TDX_ENC_STORAGE_MOUNTPOINT}"); then
+        if [ "${source}" = "${TDX_ENC_STORAGE_LOCATION}" ]; then
+            tdx_enc_log "Partition is already mounted to the specified location."
+            return 0
+        fi
+
+        tdx_enc_exit_error "Mount location already points to a different storage location."
     fi
 
     mkdir -p "${TDX_ENC_STORAGE_MOUNTPOINT}"
     if ! mount ${TDX_ENC_STORAGE_LOCATION} "${TDX_ENC_STORAGE_MOUNTPOINT}"; then
+        tdx_enc_log "Unable to mount location, possibly already encrypted..."
+        return 1
+    fi
+    return 0
+}
+
+# backup original data in partition (if not encrypted)
+tdx_enc_backup_data() {
+    if [ ${TDX_ENC_PRESERVE_DATA} -ne 1 ]; then
+        tdx_enc_log "Data preservation is not enabled"
         return 0
     fi
 
@@ -282,8 +298,25 @@ tdx_enc_backup_data() {
     if [ "$?" -ne 0 ] || echo "${msgs}" | grep -qi 'error\|invalid'; then
         tdx_enc_exit_error "Couldn't save original data."
     fi
+}
 
-    tdx_enc_log "Backup created at: ${TDX_ENC_BACKUP_FILE}"
+# call user check script
+tdx_run_user_check() {
+    TDX_ENC_USER_SCRIPT="/usr/sbin/encryption_allowed"
+    if [ -x ${TDX_ENC_USER_SCRIPT} ]; then
+        if ! [ -O ${TDX_ENC_USER_SCRIPT} -a -G ${TDX_ENC_USER_SCRIPT} ]; then
+            tdx_enc_log "WARNING: Ignoring user check script due to invalid ownership."
+        elif (( 0$(stat -c %a "${TDX_ENC_USER_SCRIPT}") & 07022 )); then
+            tdx_enc_log "WARNING: Ignoring user check script due to invalid permissions."
+        elif ! ${TDX_ENC_USER_SCRIPT}; then
+            tdx_enc_exit_error "Encryption disabled by the user!"
+        fi
+    fi
+}
+
+# unmount the partition if needed ready for encryption
+tdx_enc_pre_unmount() {
+    tdx_enc_log "Unmounting partition ready to encrypt..."
     umount "${TDX_ENC_STORAGE_MOUNTPOINT}"
 }
 
@@ -363,10 +396,14 @@ tdx_enc_partition_remove() {
 
 # mount encrypted partition
 tdx_enc_main_start() {
+    if tdx_enc_pre_mount; then
+        tdx_run_user_check
+        tdx_enc_backup_data
+        tdx_enc_pre_unmount
+    fi
     tdx_enc_prepare_generic
     tdx_enc_prepare_${TDX_ENC_KEY_BACKEND}
     tdx_enc_key_gen_${TDX_ENC_KEY_BACKEND}
-    tdx_enc_backup_data
     tdx_enc_partition_setup
     tdx_enc_partition_mount
     tdx_enc_restore_data


### PR DESCRIPTION
**Environment**
This issue was noticed when using the following components:
- tdx-reference-minimal-image
- iMX8MP Verdin SoM

**Issue**
As described in Issue [#39], if it is required to perform multiple reboots during production (e.g. for pre-testing and validation) before the SEC_BOOT fuse is "blown", then the encrypted partition will be inaccessible after blowing the eFuse.

**Cause**
This issue is caused because the partition is encrypted on first boot.
However when using the CAAM to perform the encryption, a test key is used until the SEC_BOOT eFuse is blown, at which point a real key is used.
Due to this the partition is encrypted with the test/demo key and is then not decryptable after the SEC_BOOT eFuse is blown.

**Current Workaround**
At present the process would have to be a manual step to decrypt the partition and removing the key blob before rebooting to blow the SEC_BOOT eFuse.
If this is done then the next re-boot will encrypt the partition again, this time with the real key.
This process is made more complex if there is existing initial data within the partition to be encrypted as this data will need to be "backed-up" and "restored" when decrypting the partition.
In certain industries this would have to be done in RAM using a tempFS, as some data is not allowed to be stored at any time on unencrypted media due to how easy it can be to "recover" the temporarily written data.

**Proposed Fix**
This is to add a user hook (via an external script) to prevent the initial encryption process. This will allow the user to perform any checks like SEC_BOOT fuse state before letting the encryption process proceed.

**Changes**
- Changes the process so data preservation is only checked when the partition is successfully mounted
- Adds a metod that calls out to an external script if it exists to allow users to disable the encryption process
- Updated documentation with details of the new hook
- Updated data-partition documentation to add missing variable assignment for mountpoint (fails to boot correctly if this is not set)