### PR TITLE
Add support for PKCS#11 trusted application

### DIFF
--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -11,6 +11,9 @@ MACHINE_FEATURES:append = " optee"
 TDX_OPTEE_FTPM ?= "0"
 MACHINE_FEATURES:append = " ${@oe.utils.conditional('TDX_OPTEE_FTPM', '1', 'optee-ftpm', '', d)}"
 
+# enable support for PKCS#11 trusted application
+TDX_OPTEE_PKCS11 ?= "0"
+
 # enable support for using the eMMC RPMB partition as a secure storage device
 TDX_OPTEE_FS_RPMB ?= "0"
 
@@ -44,6 +47,7 @@ TDX_OPTEE_PACKAGES_TESTS = "\
     optee-test \
     optee-examples \
     mmc-utils \
+    openssl-bin \
 "
 
 # extra packages for OP-TEE support
@@ -51,6 +55,7 @@ IMAGE_INSTALL:append = "\
     optee-os \
     optee-client \
     ${@oe.utils.conditional('TDX_OPTEE_FTPM', '1', 'tpm2-tools', '', d)} \
+    ${@oe.utils.conditional('TDX_OPTEE_PKCS11', '1', 'libp11 opensc', '', d)} \
     ${@oe.utils.conditional('TDX_OPTEE_INSTALL_TESTS', '1', '${TDX_OPTEE_PACKAGES_TESTS}', '', d)} \
 "
 

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -28,8 +28,9 @@ A few variables can be used to customize the behavior of this feature:
 | TDX_OPTEE_INSTALL_TESTS | Enable the installation of OP-TEE test applications (`1` to enable or `0` to disable) | `0` |
 | TDX_OPTEE_FS_RPMB | Enable support for using the eMMC RPMB partition as a secure storage device (`1` to enable or `0` to disable) | `0` |
 | TDX_OPTEE_FS_RPMB_DEV_ID | Configure the eMMC RPMB partition device node. For example, if configured with `2`, the TEE supplicant will use `/dev/mmcblk2rpmb` to communicate with to the RPMB partition | `0` |
-| TDX_OPTEE_FS_RPMB_MODE | RPMB secure storage operation mode. Valid options are `development` (to be used during development), `factory` (to enroll the RPMB key in a secure provisioning environment) and `production` (to be used in production). For more information on how to configure this variable, see the session [RPMB support in OP-TEE](/docs/README-optee.md#rpmb-support-in-op-tee) | `development` |
-| TDX_OPTEE_FTPM | Enable support for a firmware TPM (fTPM) implementation running as trusted application in OP-TEE (`1` to enable or `0` to disable). For more information on how an fTPM works, see the session [fTPM support in OP-TEE](/docs/README-optee.md#ftpm-support-in-op-tee) | `0` |
+| TDX_OPTEE_FS_RPMB_MODE | RPMB secure storage operation mode. Valid options are `development` (to be used during development), `factory` (to enroll the RPMB key in a secure provisioning environment) and `production` (to be used in production). For more information on how to configure this variable, see the section [RPMB support in OP-TEE](/docs/README-optee.md#rpmb-support-in-op-tee) | `development` |
+| TDX_OPTEE_FTPM | Enable support for a firmware TPM (fTPM) implementation running as trusted application in OP-TEE (`1` to enable or `0` to disable). For more information on how an fTPM works, see the section [fTPM support in OP-TEE](/docs/README-optee.md#ftpm-support-in-op-tee) | `0` |
+| TDX_OPTEE_PKCS11 | Enable support for PKCS#11 trusted application (`1` to enable or `0` to disable). For more information on how an PKCS#11 works, see the section [PKCS#11 support in OP-TEE](/docs/README-optee.md#pkcs11-support-in-op-tee) | `0` |
 
 ## Testing OP-TEE
 
@@ -131,6 +132,28 @@ And the TPM2 tools can be used to test it:
 ```
 
 It's important to note that an fTPM may not entirely replace the need for a discrete TPM chip, as this depends on the specific use case and the product's threat model. Nevertheless, an fTPM can provide adequate security for certain scenarios, especially when incorporating a hardware TPM chip is impractical.
+
+## PKCS#11 support in OP-TEE
+
+PKCS#11 (also known as the Cryptoki API) defines a set of standard calls that allow cryptographic operations (such as signing) to be offloaded to an external module. This module could be a smart card or, in the case of OP-TEE, a software PKCS#11 trusted application, which is presented to the userspace as if it were a hardware module. This trusted application is accessed through a shared object (dynamic library), which acts as the "bridge" that translates cryptographic requests into OP-TEE calls.
+
+Using this layer, the PKCS#11 Trusted Application can be enabled by adding the following line to an OE configuration file (e.g. `local.conf`):
+
+```
+TDX_OPTEE_PKCS11 = "1"
+```
+
+To verify that the PKCS#11 Trusted Application is enabled and functioning, you can use the `pkcs11-tool` command-line utility:
+
+```
+# pkcs11-tool --module /usr/lib/libckteec.so.0 --show-info
+Cryptoki version 2.40
+Manufacturer     Linaro
+Library          OP-TEE PKCS11 Cryptoki library (ver 0.1)
+Using slot 0 with a present token (0x0)
+```
+
+For additional details on how the PKCS#11 Trusted Application works, refer to the [OP-TEE official documentation](https://optee.readthedocs.io/en/latest/building/userland_integration.html#pkcs-11-driver).
 
 ## Important note
 

--- a/recipes-security/optee/optee-tdx.inc
+++ b/recipes-security/optee/optee-tdx.inc
@@ -13,6 +13,7 @@ OPTEE_OS_DEBUG_OPTS = "\
 
 # additional build flags for optee-os
 EXTRA_OEMAKE:append:pn-optee-os = "\
+    ${@oe.utils.conditional('TDX_OPTEE_PKCS11', '1', 'CFG_PKCS11_TA=y', '', d)} \
     ${@oe.utils.conditional('TDX_OPTEE_DEBUG', '1', '${OPTEE_OS_DEBUG_OPTS}', '', d)} \
     CFG_UART_BASE=${UART_BASE_ADDR} \
     ${OPTEE_OS_EXTRA_MACHINE_ARGS} \


### PR DESCRIPTION
By enabling TDX_OPTEE_PKCS11, the OP-TEE OS is compiled with the PKCS#11 Trusted Application (TA) support, and the necessary user-space tools are included in the root filesystem.

Tested on Verdin iMX8MP (fused and closed device, OP-TEE configured to use RPMB), Verdin iMX8MM (secure boot not enabled, OP-TEE using the normal world (REE) file system), and Verdin AM62 (not close, using RPMB).