### PR TITLE
Ensure BSP DATA partition variables match with tdx-tezi-data-partition and tdx-encrypted classes.

### DIFF
--- a/classes/tdx-encrypted-data-partition.bbclass
+++ b/classes/tdx-encrypted-data-partition.bbclass
@@ -1,0 +1,4 @@
+inherit tdx-tezi-data-partition
+
+inherit tdx-encrypted
+TDX_TEZI_DATA_PARTITION_MOUNTPOINT = "${TDX_ENC_STORAGE_MOUNTPOINT}"

--- a/classes/tdx-tezi-data-partition.bbclass
+++ b/classes/tdx-tezi-data-partition.bbclass
@@ -32,6 +32,7 @@ TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS ?= "rw,nosuid,nodev,noatime,errors=remount-r
 TEZI_DATA_ENABLED = "1"
 TEZI_DATA_FSTYPE = "${TDX_TEZI_DATA_PARTITION_TYPE}"
 TEZI_DATA_LABEL = "${TDX_TEZI_DATA_PARTITION_LABEL}"
+TEZI_DATA_MOUNTPOINT = "${TDX_TEZI_DATA_PARTITION_MOUNTPOINT}"
 
 # check if tezi image is enabled
 addhandler validate_tezi_support

--- a/docs/README-data-partition.md
+++ b/docs/README-data-partition.md
@@ -39,3 +39,13 @@ When the said assumption is true though, having an encrypted data partition woul
 INHERIT += "tdx-tezi-data-partition tdx-encrypted"
 TDX_ENC_STORAGE_LOCATION = "/dev/<block-device-for-data-partition>"
 ```
+
+The class `tdx-encrypted-data-partition` could be used to apply all the relevant configurations when wishing to encrypt the data partition.
+When using this class  the default value of `TDX_TEZI_DATA_PARTITION_MOUNTPOINT` will be set to the value of `TDX_ENC_STORAGE_MOUNTPOINT`.
+
+In this case you can use the following in your `local.conf` instead:
+
+```
+INHERIT += "tdx-encrypted-data-partition"
+TDX_ENC_STORAGE_LOCATION = "/dev/<block-device-for-data-partition>"
+```


### PR DESCRIPTION
**Environment:**
Image: tdx-reference-minimal-image 
Branch: Kirkstone

**Issue:**
When combining tdx-tezi-data-partition and tdx-encrypted classes in a build, the values defined for the `TEZI_DATA_MOUNTPOINT` do not match what was specified for `TDX_TEZI_DATA_PARTITION_MOUNTPOINT` or `TDX_ENC_STORAGE_MOUNTPOINT` respectivley.

**Solution:**
- Added addition to tdx-tezi-data-partition.bbclass to set the `TEZI_DATA_MOUNTPOINT` based on the value of `TDX_TEZI_DATA_PARTITION_MOUNTPOINT`.
- Added wrapper class to ensure correct flow-down of `TDX_ENC_STORAGE_MOUNTPOINT` to `TDX_TEZI_DATA_PARTITION_MOUNTPOINT` when encryption is explicitly wanted for the data partition.