### PR TITLE
Add OP-TEE support for Verdin AM69

### DIFF
--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -14,6 +14,9 @@ MACHINE_FEATURES:append = " ${@oe.utils.conditional('TDX_OPTEE_FTPM', '1', 'opte
 # enable support for PKCS#11 trusted application
 TDX_OPTEE_PKCS11 ?= "0"
 
+# root directory when using the REE filesystem for storage
+TDX_OPTEE_FS_PARENT_PATH ?= "/data/tee"
+
 # enable support for using the eMMC RPMB partition as a secure storage device
 TDX_OPTEE_FS_RPMB ?= "0"
 

--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -2,7 +2,7 @@
 TDX_OPTEE_ENABLE = "1"
 
 # disable OP-TEE on R5 firmware for K3 based platforms
-TDX_OPTEE_ENABLE:verdin-am62-k3r5 = "0"
+TDX_OPTEE_ENABLE:k3r5 = "0"
 
 # required by some vendor BSPs
 MACHINE_FEATURES:append = " optee"
@@ -72,6 +72,7 @@ addhandler validate_optee_support
 validate_optee_support[eventmask] = "bb.event.SanityCheck"
 python validate_optee_support() {
     supported_machines = [
+        'aquila-am69',
         'verdin-imx8mp',
         'verdin-imx8mm',
         'verdin-am62',

--- a/classes/tdx-tezi-data-partition.bbclass
+++ b/classes/tdx-tezi-data-partition.bbclass
@@ -41,3 +41,6 @@ python validate_tezi_support() {
     if 'teziimg' not in enabled_images:
         bb.fatal("tdx-tezi-data-partition class only works with Easy Installer images, and teziimg is not enabled!")
 }
+python validate_tezi_support:k3r5 () {
+    pass
+}

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -26,6 +26,7 @@ A few variables can be used to customize the behavior of this feature:
 | :------- | :---------- | :------------ |
 | TDX_OPTEE_DEBUG | Enable OP-TEE debug messages to the serial console (`1` to enable or `0` to disable) | `0` |
 | TDX_OPTEE_INSTALL_TESTS | Enable the installation of OP-TEE test applications (`1` to enable or `0` to disable) | `0` |
+| TDX_OPTEE_FS_PARENT_PATH | Defines the root directory when using the REE (Rich Execution Environment) filesystem for storage | `/data/tee` |
 | TDX_OPTEE_FS_RPMB | Enable support for using the eMMC RPMB partition as a secure storage device (`1` to enable or `0` to disable) | `0` |
 | TDX_OPTEE_FS_RPMB_DEV_ID | Configure the eMMC RPMB partition device node. For example, if configured with `2`, the TEE supplicant will use `/dev/mmcblk2rpmb` to communicate with to the RPMB partition | `0` |
 | TDX_OPTEE_FS_RPMB_MODE | RPMB secure storage operation mode. Valid options are `development` (to be used during development), `factory` (to enroll the RPMB key in a secure provisioning environment) and `production` (to be used in production). For more information on how to configure this variable, see the section [RPMB support in OP-TEE](/docs/README-optee.md#rpmb-support-in-op-tee) | `development` |
@@ -63,7 +64,7 @@ There are currently two secure storage implementations in OP-TEE:
 - The first one relies on the normal world (REE) file system.
 - The second one makes use of the Replay Protected Memory Block (RPMB) partition of an eMMC device.
 
-When relying on the normal world file system, OP-TEE uses `/data/tee/` as its secure storage location in the Linux file system. All stored data is encrypted using a Hardware Unique Key (HUK), which is supplied by the CAAM driver on i.MX platforms and the DMSC subsystem on K3-based devices (e.g., AM6X).
+When relying on the normal world file system, OP-TEE will use `/data/tee/` as its secure storage location in the Linux file system (this directory can be changed via the `TDX_OPTEE_FS_PARENT_PATH` variable). All stored data is encrypted using a Hardware Unique Key (HUK), which is supplied by the CAAM driver on i.MX platforms and the DMSC subsystem on K3-based devices (e.g., AM6X).
 
 To be able to write and persist data, OP-TEE needs a read-write filesystem mounted at `/data`. When rootfs signature checking is enabled via the `tdxref-signed` class, the rootfs image will be generated using the `dm-verity` kernel feature, which is read-only. In this case, to provide a read-write filesystem to OP-TEE, the `tdx-tezi-data-partition` class will be automatically inherited. This class will create an additional partition in the eMMC and mount it by default at `/data`. For more information on how this class works, have a look at its documentation ([README-data-partition.md](README-data-partition.md)).
 

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -8,9 +8,10 @@ TEE might be a good solution to store and manage secrets (e.g. encryption keys) 
 
 This layer provides support for running OP-TEE on the following SoMs:
 
+- Aquila AM69
+- Verdin AM62
 - Verdin iMX8MP
 - Verdin iMX8MM
-- Verdin AM62
 
 ## Enabling OP-TEE
 

--- a/recipes-security/optee/include/optee-tdx-aquila-am69.inc
+++ b/recipes-security/optee/include/optee-tdx-aquila-am69.inc
@@ -1,0 +1,2 @@
+# eMMC RPMB partition device node ID
+TDX_OPTEE_FS_RPMB_DEV_ID ?= "0"

--- a/recipes-security/optee/optee-client_%.bbappend
+++ b/recipes-security/optee/optee-client_%.bbappend
@@ -16,11 +16,13 @@ do_install:append() {
 # additional build flags for RPMB support in NXP downstream OP-TEE client (Makefile based)
 EXTRA_OEMAKE:append = "\
     ${@oe.utils.conditional('TDX_OPTEE_DEBUG', '1', 'CFG_TEE_SUPP_LOG_LEVEL=3', '', d)} \
+    CFG_TEE_FS_PARENT_PATH='${TDX_OPTEE_FS_PARENT_PATH}' \
 "
 
 # additional build flags for RPMB support in upstream OP-TEE client (CMake based)
 EXTRA_OECMAKE:append = "\
     ${@oe.utils.conditional('TDX_OPTEE_DEBUG', '1', '-DCFG_TEE_SUPP_LOG_LEVEL=3', '', d)} \
+    -DCFG_TEE_FS_PARENT_PATH='${TDX_OPTEE_FS_PARENT_PATH}' \
 "
 
 require ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB', '1', 'optee-fs-rpmb.inc', '', d)}

--- a/recipes-security/optee/optee-client_%.bbappend
+++ b/recipes-security/optee/optee-client_%.bbappend
@@ -13,8 +13,14 @@ do_install:append() {
     fi
 }
 
+# additional build flags for RPMB support in NXP downstream OP-TEE client (Makefile based)
 EXTRA_OEMAKE:append = "\
     ${@oe.utils.conditional('TDX_OPTEE_DEBUG', '1', 'CFG_TEE_SUPP_LOG_LEVEL=3', '', d)} \
+"
+
+# additional build flags for RPMB support in upstream OP-TEE client (CMake based)
+EXTRA_OECMAKE:append = "\
+    ${@oe.utils.conditional('TDX_OPTEE_DEBUG', '1', '-DCFG_TEE_SUPP_LOG_LEVEL=3', '', d)} \
 "
 
 require ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB', '1', 'optee-fs-rpmb.inc', '', d)}


### PR DESCRIPTION
This adds OP-TEE support for Verdin AM69, including RPMB as a secure storage device, fTPM and PKCS#11 trusted applications.