### PR TITLE
Add support for secure boot on Aquila AM69

### DIFF
--- a/classes/tdx-signed-fit-image.inc
+++ b/classes/tdx-signed-fit-image.inc
@@ -4,7 +4,7 @@ KERNEL_IMAGETYPE:forcevariable = "fitImage"
 
 # enable signature checking of FIT images
 UBOOT_SIGN_ENABLE ?= "1"
-UBOOT_SIGN_ENABLE:verdin-am62-k3r5 = "0"
+UBOOT_SIGN_ENABLE:k3r5 = "0"
 UBOOT_MKIMAGE_DTCOPTS = "-I dts -O dtb -p 2000"
 UBOOT_SIGN_KEYDIR ?= "${TOPDIR}/keys/fit"
 UBOOT_SIGN_KEYNAME ?= "dev"

--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -42,6 +42,7 @@ TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mm ?= "ro rootwait console=tty1 console
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mp ?= "ro rootwait console=tty1 console=ttymxc2,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx8x ?= "ro rootwait console=tty1 console=ttyLP3,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-am62 ?= "ro rootwait console=tty1 console=ttyS2,115200"
+TDX_SECBOOT_REQUIRED_BOOTARGS:aquila-am69 ?= "ro rootwait console=tty1 console=ttyS2,115200"
 
 # Name of the overlay file (without extension) that will contain the fixed part
 # of the kernel command line; this will be stored inside the FIT image; notice

--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -24,7 +24,7 @@ def default_tdx_uboot_hardening_enable(d):
     return False
 
 TDX_UBOOT_HARDENING_ENABLE ?= "${@'1' if default_tdx_uboot_hardening_enable(d) else '0'}"
-TDX_UBOOT_HARDENING_ENABLE:verdin-am62-k3r5 = "0"
+TDX_UBOOT_HARDENING_ENABLE:k3r5 = "0"
 TDX_UBOOT_HARDENING_ENABLE_DBG ?= "0"
 
 # Configure the "kernel command-line protection"; with this protection, the

--- a/classes/tdx-signed-k3-hs-se-tiboot3-aquila-am69.inc
+++ b/classes/tdx-signed-k3-hs-se-tiboot3-aquila-am69.inc
@@ -1,0 +1,2 @@
+# use tiboot3.bin secure boot variant in Tezi
+FIRMWARE_BINARY[0088] = "tiboot3-am69-hs-aquila.bin"

--- a/classes/tdx-signed-k3-hs-se-tiboot3-verdin-am62.inc
+++ b/classes/tdx-signed-k3-hs-se-tiboot3-verdin-am62.inc
@@ -1,0 +1,5 @@
+# use tiboot3.bin secure boot variant in Tezi
+FIRMWARE_BINARY[0073] = "tiboot3-am62x-hs-verdin.bin"
+FIRMWARE_BINARY[0074] = "tiboot3-am62x-hs-verdin.bin"
+FIRMWARE_BINARY[0075] = "tiboot3-am62x-hs-verdin.bin"
+FIRMWARE_BINARY[0076] = "tiboot3-am62x-hs-verdin.bin"

--- a/classes/tdx-signed-k3-hs-se-tiboot3.inc
+++ b/classes/tdx-signed-k3-hs-se-tiboot3.inc
@@ -1,8 +1,5 @@
 # build secure variant of tiboot3.bin
 SYSFW_SUFFIX = "hs"
 
-# use tiboot3.bin secure boot variant in Tezi
-FIRMWARE_BINARY[0073] = "tiboot3-am62x-hs-verdin.bin"
-FIRMWARE_BINARY[0074] = "tiboot3-am62x-hs-verdin.bin"
-FIRMWARE_BINARY[0075] = "tiboot3-am62x-hs-verdin.bin"
-FIRMWARE_BINARY[0076] = "tiboot3-am62x-hs-verdin.bin"
+# include machine-specific tiboot3 configuration
+include tdx-signed-k3-hs-se-tiboot3-${MACHINE}.inc

--- a/docs/README-secure-boot-k3.md
+++ b/docs/README-secure-boot-k3.md
@@ -6,13 +6,13 @@ This document describes how bootloader signature checking works for System on Mo
 
 The Texas Instruments K3 platform encompasses a family of SoCs (System on Chips) designed to offer a blend of multicore processing capabilities, optimized for high performance and power efficiency across a broad array of industrial, automotive, and other market segments.
 
-The AM62x family of SoCs (part of the K3 platform) has two types of devices: GP (General Purpose) and HS (High Security).
+The AM6x family of SoCs (part of the K3 platform) has two types of devices: GP (General Purpose) and HS (High Security).
 
 General Purpose (GP) devices lack several security features and don't support secure boot.
 
 High Security (HS) devices have all security features available and support encrypted and authenticated (secure) boot.
 
-**IMPORTANT**: To have access to the secure boot feature on Verdin AM62, make sure you are using an SoC of type HS.
+**IMPORTANT**: To have access to the secure boot feature on AM6x based SoMs (Verdin AM62, Aquila AM69), make sure you are using an SoC of type HS.
 
 A High Security (HS) device might be in one of two different states:
 
@@ -21,7 +21,7 @@ A High Security (HS) device might be in one of two different states:
 
 For more details on how secure boot works on K3 platforms, it is recommended to read the documentation provided by Texas Instruments. Since most documentation related to security is provided under NDA, you will need to talk to a TI Sales representative.
 
-## Enabling secure boot on Verdin AM62
+## Enabling secure boot on AM6x based devices
 
 There are three major steps to enable secure boot on Verdin AM62:
 
@@ -94,7 +94,7 @@ To finish, remove write access to the keys and certificates:
 $ chmod a-w *
 ```
 
-### Signing bootloader artefacts
+### Signing bootloader artifacts
 
 When the `tdx-signed` class is inherited, signing bootloader images on K3-based platforms like AM62 is enabled by default.
 
@@ -115,7 +115,7 @@ OTP Key Writer is a single firmware image that has three components:
 - A secure firmware encrypted and signed by TI (provided under NDA) that will run on the ARM Cortex M4 core, being responsible for writing to the fuses.
 - A firmware developed by the user that will run on the ARM Cortex R5 core, being responsible for parsing the certificate and sending messages to the secure firmware, so the keys and other information are written to the OTP fuses.
   
-Also, the VPP pin from the SoC requires 1.8v while programming OTP eFuses and should be floating when not programming. That means the hardware needs to be designed in a way that the state of the VPP pin can be controlled by the OTP Key Writer firmware (e.g. via GPIO pin).
+Also, the *VPP* pins from the SoC (*VPP* on AM62, *VPP_CORE* and *VPP_MCU* on AM69) require 1.8v while programming OTP eFuses and should be floating when not programming. That means the hardware needs to be designed in a way that the state of the *VPP* pins can be controlled by the OTP Key Writer firmware (e.g. via GPIO pin).
 
 The [OTP Keywriter Tutorial](https://dev.ti.com/tirex/explore/node?node=A__AagJ-8QGXM582KzTgxFZbA__AM62-ACADEMY__uiYMDcq__LATEST) provided by TI might help to understand how to implement the OTP KeyWriter software.
 

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -6,6 +6,7 @@ Secure boot is currently supported on the following SoMs:
 
 - Apalis iMX6
 - Apalis iMX8
+- Aquila AM69
 - Colibri iMX6DL
 - Colibri iMX6ULL (1GB eMMC variant only)
 - Colibri iMX7D (1GB eMMC variant only)
@@ -50,7 +51,7 @@ The bootloader signature checking implementation is dependent on the System on C
 
 For details on the bootloader signature checking implementation for SoMs that use NXP iMX-based platforms (i.e. iMX6/7/8), see the [README-secure-boot-imx.md](README-secure-boot-imx.md) file.
 
-For details on the bootloader signature checking implementation for SoMs that use TI K3-based platforms (i.e. AM62), see the [README-secure-boot-k3.md](README-secure-boot-k3.md) file.
+For details on the bootloader signature checking implementation for SoMs that use TI K3-based platforms (i.e. AM62/AM69), see the [README-secure-boot-k3.md](README-secure-boot-k3.md) file.
 
 ## U-Boot hardening
 
@@ -94,7 +95,7 @@ TDX_SECBOOT_WL_ALLOW_CLOSED_CATEG = "CMD_CAT_ALL_SAFE CMD_CAT_GPIO_CONTROL"
 
 ### U-Boot hardening / known issues
 
-- On the **Verdin AM62** SoM, the hardening does not cover the bootloader running on the R5 processor (the boot master); we have plans to evaluate the need for such a protection and implementing it if actually needed.
+- On K3 based platforms (Verdin AM62, Aquila AM69), the hardening does not cover the bootloader running on the R5 processor (the boot master); we have plans to evaluate the need for such a protection and implementing it if actually needed.
 
 ## Configuring FIT image signing
 
@@ -116,7 +117,7 @@ The complete list of variables can be found in the `tdx-signed-fit-image.inc` fi
 
 ### Configuring FIT image signing / known issues
 
-- On the **Verdin AM62** SoM, some of the configuration variables (e.g. `UBOOT_SIGN_KEYDIR`, `UBOOT_SIGN_KEYNAME` (check the complete list in `tdx-signed-fit-image.inc`)) are set through override `k3` to ensure the values coming from layer `meta-toradex-security` override those from layer `meta-ti-bsp`. Due to this, the recommended way to set those variables is via override `forcevariable`.
+- On K3 based platforms (Verdin AM62, Aquila AM69), some of the configuration variables (e.g. `UBOOT_SIGN_KEYDIR`, `UBOOT_SIGN_KEYNAME` (check the complete list in `tdx-signed-fit-image.inc`)) are set through override `k3` to ensure the values coming from layer `meta-toradex-security` override those from layer `meta-ti-bsp`. Due to this, the recommended way to set those variables is via override `forcevariable`.
 
 ## Configuring rootfs image signing
 

--- a/recipes-bsp/u-boot/files/0001-toradex-add-helper-to-detect-closed-device-k3.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-add-helper-to-detect-closed-device-k3.patch
@@ -1,7 +1,7 @@
 From c8f0e86b1382b7d2ffbab5f2805e1d069a39cd7e Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 9 Oct 2024 20:23:16 -0300
-Subject: [PATCH] toradex: add helper to detect closed k3 device (am62)
+Subject: [PATCH] toradex: add helper to detect closed device (k3)
 
 Upstream-Status: Inappropriate [Torizon OS specific]
 

--- a/recipes-bsp/u-boot/files/0001-toradex-integrate-command-whitelisting-k3.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-integrate-command-whitelisting-k3.patch
@@ -1,7 +1,7 @@
 From 29256c1438a006454bc17dd379b11d885fe7d1ac Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:29:34 -0300
-Subject: [PATCH 1/7] toradex: integrate command whitelisting (am62)
+Subject: [PATCH 1/7] toradex: integrate command whitelisting (k3)
 
 v1:
 

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootargs-protection-k3.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootargs-protection-k3.patch
@@ -1,7 +1,7 @@
 From 4f82c2f035ad004244482a7a297d78602ae87c0c Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 26 Oct 2023 12:40:46 -0300
-Subject: [PATCH 4/7] toradex: integrate bootargs protection (am62)
+Subject: [PATCH 4/7] toradex: integrate bootargs protection (k3)
 
 Upstream-Status: Inappropriate [Torizon OS specific]
 

--- a/recipes-bsp/u-boot/u-boot-fit-signature.inc
+++ b/recipes-bsp/u-boot/u-boot-fit-signature.inc
@@ -4,4 +4,4 @@ SRC_URI:append = "\
 
 require ${@ 'u-boot-fit-signature-nxp.inc' if 'imx-generic-bsp' in d.getVar('OVERRIDES').split(':') else ''}
 
-require ${@ 'u-boot-fit-signature-ti.inc' if 'am62xx' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'u-boot-fit-signature-ti.inc' if 'k3' in d.getVar('OVERRIDES').split(':') else ''}

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -14,12 +14,12 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM = "\
     file://0007-toradex-cmd-setexpr-integrate-protections-downstream.patch \
 "
 
-TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62 = "\
+TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_K3 = "\
     ${TDX_UBOOT_HARDENING_PATCHES_COMMON} \
-    file://0001-toradex-integrate-command-whitelisting-am62.patch \
+    file://0001-toradex-integrate-command-whitelisting-k3.patch \
     file://0002-toradex-integrate-bootm-protection-downstream.patch \
     file://0003-toradex-integrate-CLI-access-protection-downstream.patch \
-    file://0004-toradex-integrate-bootargs-protection-am62.patch \
+    file://0004-toradex-integrate-bootargs-protection-k3.patch \
     file://0005-toradex-cmd-fuse-add-switch-for-quiet-operation-down.patch \
     file://0006-toradex-cmd-fuse-add-readv-command-downstream.patch \
     file://0007-toradex-cmd-setexpr-integrate-protections-downstream.patch \
@@ -39,8 +39,8 @@ TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
 TDX_UBOOT_HARDENING_PATCHES = "${TDX_UBOOT_HARDENING_PATCHES_UPSTREAM}"
 TDX_UBOOT_HARDENING_PATCHES:apalis-imx8 = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM}"
 TDX_UBOOT_HARDENING_PATCHES:colibri-imx8x = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM}"
-TDX_UBOOT_HARDENING_PATCHES:verdin-am62 = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_AM62}"
-TDX_UBOOT_HARDENING_PATCHES:verdin-am62-k3r5 = ""
+TDX_UBOOT_HARDENING_PATCHES:k3 = "${TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_K3}"
+TDX_UBOOT_HARDENING_PATCHES:k3r5 = ""
 
 SRC_URI:append = "\
     file://u-boot-harden.cfg \

--- a/recipes-bsp/u-boot/u-boot-secure-boot.inc
+++ b/recipes-bsp/u-boot/u-boot-secure-boot.inc
@@ -14,17 +14,17 @@ TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM = " \
     file://0001-toradex-integrate-shared-secboot-module-downstream.patch \
 "
 
-TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM_AM62 = " \
+TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM_K3 = " \
     ${TDX_UBOOT_SECBOOT_PATCHES_COMMON} \
-    file://0001-toradex-add-helper-to-detect-closed-k3-device-am62.patch \
+    file://0001-toradex-add-helper-to-detect-closed-device-k3.patch \
     file://0001-toradex-integrate-shared-secboot-module-downstream.patch \
 "
 
 TDX_UBOOT_SECBOOT_PATCHES = "${TDX_UBOOT_SECBOOT_PATCHES_UPSTREAM}"
 TDX_UBOOT_SECBOOT_PATCHES:apalis-imx8 = "${TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM}"
 TDX_UBOOT_SECBOOT_PATCHES:colibri-imx8x = "${TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM}"
-TDX_UBOOT_SECBOOT_PATCHES:verdin-am62 = "${TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM_AM62}"
-TDX_UBOOT_SECBOOT_PATCHES:verdin-am62-k3r5 = ""
+TDX_UBOOT_SECBOOT_PATCHES:k3 = "${TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM_K3}"
+TDX_UBOOT_SECBOOT_PATCHES:k3r5 = ""
 
 SRC_URI:append = " \
     ${TDX_UBOOT_SECBOOT_PATCHES} \


### PR DESCRIPTION
Build and runtime tested on Verdin AM62 (closed device).

Build and (partially) runtime tested on Aquila AM69 (opened device).

Testing on a closed AM69 device is still pending due to missing software artifacts required for SoC fusing. Once we receive these artifacts from TI, we will proceed with the tests.

Despite this, the PR is considered ready for merge.