### PR TITLE
Add explicit self-overwrite safeguard to "load" command plus fixes to built-in protection

### DIFF
--- a/recipes-bsp/u-boot/files/0001-lmb-prevent-alloc-overlap-with-reserved-regions-k3.patch
+++ b/recipes-bsp/u-boot/files/0001-lmb-prevent-alloc-overlap-with-reserved-regions-k3.patch
@@ -1,0 +1,84 @@
+From 3c86dfe96b06352231670bdbc47a06c0a8b01c40 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Wed, 12 Mar 2025 19:47:36 -0300
+Subject: [PATCH] lmb: prevent alloc overlap with reserved regions (k3)
+
+Add explicit check into lmb_alloc_addr() to prevent the allocated memory
+range to overlap with reserved regions. Also, change the return value of
+the function when the allocation is unsuccessful to prevent failures to
+allocate address 0x0 from being misinterpreted as a success.
+
+The function lmb_alloc_addr() is currently called only in the context of
+the "load" command so that the present change should only impact that
+particular command and no other U-Boot functionality.
+
+Upstream-Status: Pending
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ lib/lmb.c | 43 +++++++++++++++++++++++++++++++------------
+ 1 file changed, 31 insertions(+), 12 deletions(-)
+
+diff --git a/lib/lmb.c b/lib/lmb.c
+index 44f98205310..8bcceb47bd7 100644
+--- a/lib/lmb.c
++++ b/lib/lmb.c
+@@ -505,24 +505,43 @@ phys_addr_t __lmb_alloc_base(struct lmb *lmb, phys_size_t size, ulong align, phy
+  */
+ phys_addr_t lmb_alloc_addr(struct lmb *lmb, phys_addr_t base, phys_size_t size)
+ {
++	int i;
+ 	long rgn;
+ 
+ 	/* Check if the requested address is in one of the memory regions */
+ 	rgn = lmb_overlaps_region(&lmb->memory, base, size);
+-	if (rgn >= 0) {
+-		/*
+-		 * Check if the requested end address is in the same memory
+-		 * region we found.
+-		 */
+-		if (lmb_addrs_overlap(lmb->memory.region[rgn].base,
+-				      lmb->memory.region[rgn].size,
+-				      base + size - 1, 1)) {
+-			/* ok, reserve the memory */
+-			if (lmb_reserve(lmb, base, size) >= 0)
+-				return base;
++	if (rgn < 0)
++		goto err;
++
++	/* Ensure end address is in the same memory region we found */
++	if (!lmb_addrs_overlap(lmb->memory.region[rgn].base,
++			       lmb->memory.region[rgn].size,
++			       base + size - 1, 1))
++		goto err;
++
++	/* Check for overlap with reserved regions */
++	for (i = 0; i < lmb->reserved.cnt; i++) {
++		if (lmb_addrs_overlap(lmb->reserved.region[i].base,
++				      lmb->reserved.region[i].size,
++				      base, size)) {
++			debug("Requested range overlaps with region "
++			      "reserved[%d]: [0x%llx-0x%llx]\n", i,
++			      (u64) lmb->reserved.region[i].base,
++			      ((u64) lmb->reserved.region[i].base +
++			       lmb->reserved.region[i].size - 1));
++			goto err;
+ 		}
+ 	}
+-	return 0;
++
++	/* All good, reserve the memory. */
++	if (lmb_reserve(lmb, base, size) >= 0)
++		return base;
++
++err:
++	debug("Couldn't allocate range [0x%llx-0x%llx]\n",
++	      (u64) base, (u64) base + size - 1);
++
++	return (phys_addr_t) -1;
+ }
+ 
+ /* Return number of bytes from a given address that are free */
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/0001-lmb-prevent-alloc-overlap-with-reserved-regions-upst.patch
+++ b/recipes-bsp/u-boot/files/0001-lmb-prevent-alloc-overlap-with-reserved-regions-upst.patch
@@ -1,0 +1,84 @@
+From 98952b7953467fbd4598eb5171d9377a596fa0e0 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Wed, 12 Mar 2025 19:47:36 -0300
+Subject: [PATCH] lmb: prevent alloc overlap with reserved regions (upstream)
+
+Add explicit check into lmb_alloc_addr() to prevent the allocated memory
+range to overlap with reserved regions. Also, change the return value of
+the function when the allocation is unsuccessful to prevent failures to
+allocate address 0x0 from being misinterpreted as a success.
+
+The function lmb_alloc_addr() is currently called only in the context of
+the "load" command so that the present change should only impact that
+particular command and no other U-Boot functionality.
+
+Upstream-Status: Pending
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ lib/lmb.c | 43 +++++++++++++++++++++++++++++++------------
+ 1 file changed, 31 insertions(+), 12 deletions(-)
+
+diff --git a/lib/lmb.c b/lib/lmb.c
+index 44f98205310..8bcceb47bd7 100644
+--- a/lib/lmb.c
++++ b/lib/lmb.c
+@@ -505,24 +505,43 @@ phys_addr_t __lmb_alloc_base(struct lmb *lmb, phys_size_t size, ulong align, phy
+  */
+ phys_addr_t lmb_alloc_addr(struct lmb *lmb, phys_addr_t base, phys_size_t size)
+ {
++	int i;
+ 	long rgn;
+ 
+ 	/* Check if the requested address is in one of the memory regions */
+ 	rgn = lmb_overlaps_region(&lmb->memory, base, size);
+-	if (rgn >= 0) {
+-		/*
+-		 * Check if the requested end address is in the same memory
+-		 * region we found.
+-		 */
+-		if (lmb_addrs_overlap(lmb->memory.region[rgn].base,
+-				      lmb->memory.region[rgn].size,
+-				      base + size - 1, 1)) {
+-			/* ok, reserve the memory */
+-			if (lmb_reserve(lmb, base, size) >= 0)
+-				return base;
++	if (rgn < 0)
++		goto err;
++
++	/* Ensure end address is in the same memory region we found */
++	if (!lmb_addrs_overlap(lmb->memory.region[rgn].base,
++			       lmb->memory.region[rgn].size,
++			       base + size - 1, 1))
++		goto err;
++
++	/* Check for overlap with reserved regions */
++	for (i = 0; i < lmb->reserved.cnt; i++) {
++		if (lmb_addrs_overlap(lmb->reserved.region[i].base,
++				      lmb->reserved.region[i].size,
++				      base, size)) {
++			debug("Requested range overlaps with region "
++			      "reserved[%d]: [0x%llx-0x%llx]\n", i,
++			      (u64) lmb->reserved.region[i].base,
++			      ((u64) lmb->reserved.region[i].base +
++			       lmb->reserved.region[i].size - 1));
++			goto err;
+ 		}
+ 	}
+-	return 0;
++
++	/* All good, reserve the memory. */
++	if (lmb_reserve(lmb, base, size) >= 0)
++		return base;
++
++err:
++	debug("Couldn't allocate range [0x%llx-0x%llx]\n",
++	      (u64) base, (u64) base + size - 1);
++
++	return (phys_addr_t) -1;
+ }
+ 
+ /* Return number of bytes from a given address that are free */
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/0001-toradex-common-add-shared-hardening-modules.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-common-add-shared-hardening-modules.patch
@@ -97,7 +97,7 @@ index 00000000000..d325620e998
 +};
 +
 +static enum dbg_hdn_status_t dbg_hdn_status = DBG_HDN_STATUS_AUTO;
-+#endif
++#endif /* CONFIG_TDX_SECBOOT_HARDENING_DBG */
 +
 +#ifdef CONFIG_TDX_BOOTARGS_PROTECTION
 +/* Path of node in OS FDT containing all bootargs properties. */
@@ -127,7 +127,7 @@ index 00000000000..d325620e998
 +};
 +
 +#define BOOTARG_SPEC_LEN (sizeof(bootarg_spec) / sizeof(bootarg_spec[0]))
-+#endif
++#endif /* CONFIG_TDX_BOOTARGS_PROTECTION */
 +
 +static int _tdx_hardening_enabled(void)
 +{
@@ -243,7 +243,7 @@ index 00000000000..d325620e998
 +	panic("## ERROR: \"%s\" returned (code %d) and CLI access is "
 +	      "disabled\n", cmd, rc);
 +}
-+#endif
++#endif /* CONFIG_TDX_CLI_PROTECTION */
 +
 +#ifdef CONFIG_TDX_BOOTARGS_PROTECTION
 +/**
@@ -438,7 +438,7 @@ index 00000000000..d325620e998
 +	eprintf("##  B: \"%.*s\"\n", req_len, req_args);
 +	return 0;
 +}
-+#endif
++#endif /* CONFIG_TDX_BOOTARGS_PROTECTION */
 +
 +static int show_hardening_info(void)
 +{

--- a/recipes-bsp/u-boot/files/0001-toradex-common-add-shared-secboot-module.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-common-add-shared-secboot-module.patch
@@ -299,7 +299,7 @@ index 00000000000..ee2dfdd884e
 +	}
 +
 +	if (prop) {
-+		int ret, val;
++		int val;
 +		/* Return an exit code of 16 to indicate an unknown property. */
 +		if (_secboot_get_prop(prop, &val) != 0) {
 +			eprintf("Unknown property: %s\n", prop);

--- a/recipes-bsp/u-boot/files/0001-toradex-integrate-command-whitelisting-downstream.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-integrate-command-whitelisting-downstream.patch
@@ -1,7 +1,7 @@
-From 991a6c8f0ab0c87447210b3760fa2b1c1a902f30 Mon Sep 17 00:00:00 2001
+From 06401c26057163cad232c96a69916afd56e0ad0c Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:29:34 -0300
-Subject: [PATCH 1/7] toradex: integrate command whitelisting (downstream)
+Subject: [PATCH 1/8] toradex: integrate command whitelisting (downstream)
 
 v1:
 

--- a/recipes-bsp/u-boot/files/0001-toradex-integrate-command-whitelisting-k3.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-integrate-command-whitelisting-k3.patch
@@ -1,7 +1,7 @@
-From 29256c1438a006454bc17dd379b11d885fe7d1ac Mon Sep 17 00:00:00 2001
+From 430749ceb11ccffbbaae0140f2d5c43e322fbbcd Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:29:34 -0300
-Subject: [PATCH 1/7] toradex: integrate command whitelisting (k3)
+Subject: [PATCH 1/8] toradex: integrate command whitelisting (k3)
 
 v1:
 

--- a/recipes-bsp/u-boot/files/0001-toradex-integrate-command-whitelisting-upstream.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-integrate-command-whitelisting-upstream.patch
@@ -1,7 +1,7 @@
-From 02a5998c98e0dbe094818e30f9f0b9a58a4cdb90 Mon Sep 17 00:00:00 2001
+From d9a8c7c84c28f814c7b5b8fa3491aa8c0a01f08b Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Mon, 28 Aug 2023 13:29:34 -0300
-Subject: [PATCH 1/7] toradex: integrate command whitelisting (upstream)
+Subject: [PATCH 1/8] toradex: integrate command whitelisting (upstream)
 
 v1:
 

--- a/recipes-bsp/u-boot/files/0002-toradex-integrate-bootm-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0002-toradex-integrate-bootm-protection-downstream.patch
@@ -1,7 +1,7 @@
-From 2b6de73282fdbf84c8f4e30744d91a0f3d98ab19 Mon Sep 17 00:00:00 2001
+From 6bb8cb410575f70811c15fa12d9b1be2021a2209 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 26 Jun 2024 16:08:52 -0300
-Subject: [PATCH 2/7] toradex: integrate bootm protection (downstream)
+Subject: [PATCH 2/8] toradex: integrate bootm protection (downstream)
 
 Integrate the protection to the bootm command to only allow booting
 from FIT images. With the proper configuration of U-Boot (enabling FIT
@@ -17,7 +17,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  2 files changed, 70 insertions(+), 1 deletion(-)
 
 diff --git a/Kconfig b/Kconfig
-index badab0318d6..258de43d449 100644
+index 5f6ec0afbbf..73a0dd8cfd8 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -746,6 +746,7 @@ source "tools/Kconfig"

--- a/recipes-bsp/u-boot/files/0002-toradex-integrate-bootm-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0002-toradex-integrate-bootm-protection-upstream.patch
@@ -1,7 +1,7 @@
-From 6ced049f833c0b78b6e1235b3e297f7f2e4e5736 Mon Sep 17 00:00:00 2001
+From 8b7785cadc7b75c0503c547bd253ef660f4b5e5d Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 26 Jun 2024 16:08:52 -0300
-Subject: [PATCH 2/7] toradex: integrate bootm protection (upstream)
+Subject: [PATCH 2/8] toradex: integrate bootm protection (upstream)
 
 Integrate the protection to the bootm command to only allow booting
 from FIT images. With the proper configuration of U-Boot (enabling FIT

--- a/recipes-bsp/u-boot/files/0003-toradex-integrate-CLI-access-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0003-toradex-integrate-CLI-access-protection-downstream.patch
@@ -1,7 +1,7 @@
-From df7b2d7333d73960600c312b1fbf976de7c008a6 Mon Sep 17 00:00:00 2001
+From e4cd131e9a90e2ee84343f18e8b46d888e864e0c Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 16 Oct 2024 19:10:41 -0300
-Subject: [PATCH 3/7] toradex: integrate CLI access protection (downstream)
+Subject: [PATCH 3/8] toradex: integrate CLI access protection (downstream)
 
 Integrate the protection in U-Boot to prevent access to its CLI once the
 device is closed; this is part of the hardening for Secure Boot.
@@ -15,7 +15,7 @@ Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
  2 files changed, 12 insertions(+)
 
 diff --git a/Kconfig b/Kconfig
-index 258de43d449..f8df1a262a1 100644
+index 73a0dd8cfd8..d39a38879cc 100644
 --- a/Kconfig
 +++ b/Kconfig
 @@ -747,6 +747,7 @@ config TDX_SECBOOT_HARDENING

--- a/recipes-bsp/u-boot/files/0003-toradex-integrate-CLI-access-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0003-toradex-integrate-CLI-access-protection-upstream.patch
@@ -1,7 +1,7 @@
-From 97233c46d64d96c35bde2a03e9452e20994961a5 Mon Sep 17 00:00:00 2001
+From 90e5b16505e73708ff93d050458cc214e2c353c7 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 16 Oct 2024 17:51:27 -0300
-Subject: [PATCH 3/7] toradex: integrate CLI access protection (upstream)
+Subject: [PATCH 3/8] toradex: integrate CLI access protection (upstream)
 
 Integrate the protection in U-Boot to prevent access to its CLI once the
 device is closed; this is part of the hardening for Secure Boot.

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootargs-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootargs-protection-downstream.patch
@@ -1,7 +1,7 @@
-From 356e84f2b15a6b19d50218e32d659346d0678d27 Mon Sep 17 00:00:00 2001
+From 539cace106a0ea51c9f02ce786c95e0d2cf9f84a Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 26 Oct 2023 12:40:46 -0300
-Subject: [PATCH 4/7] toradex: integrate bootargs protection (downstream)
+Subject: [PATCH 4/8] toradex: integrate bootargs protection (downstream)
 
 Upstream-Status: Inappropriate [Torizon OS specific]
 

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootargs-protection-k3.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootargs-protection-k3.patch
@@ -1,7 +1,7 @@
-From 4f82c2f035ad004244482a7a297d78602ae87c0c Mon Sep 17 00:00:00 2001
+From 506a47e5701244cc8d861a03f468ea974fa322fe Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 26 Oct 2023 12:40:46 -0300
-Subject: [PATCH 4/7] toradex: integrate bootargs protection (k3)
+Subject: [PATCH 4/8] toradex: integrate bootargs protection (k3)
 
 Upstream-Status: Inappropriate [Torizon OS specific]
 

--- a/recipes-bsp/u-boot/files/0004-toradex-integrate-bootargs-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0004-toradex-integrate-bootargs-protection-upstream.patch
@@ -1,7 +1,7 @@
-From 9767d519128e702f9e1eda6ecfb2495e6133dacb Mon Sep 17 00:00:00 2001
+From cbbd1917f4889efa7da37db2644572b74e1a32c1 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 26 Oct 2023 12:40:46 -0300
-Subject: [PATCH 4/7] toradex: integrate bootargs protection (upstream)
+Subject: [PATCH 4/8] toradex: integrate bootargs protection (upstream)
 
 Upstream-Status: Inappropriate [Torizon OS specific]
 

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-downstream.patch
@@ -1,0 +1,160 @@
+From 59665281d572d5793d3c1e1bda1efe5ca8b82da6 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Fri, 7 Mar 2025 15:56:56 -0300
+Subject: [PATCH 5/8] toradex: integrate load protection (downstream)
+
+This introduces an extra protection to the "load" command. When this
+protection is enabled (by CONFIG_TDX_LOAD_PROTECTION) the command will
+only allow the loading of files in the address range:
+
+- [R0, R0+1G-64M) on devices with at least 1GB of SDRAM.
+- [R0, R0+512M-64M) on devices with less than 1GB of SDRAM.
+
+where R0 stands for the initial address of the SDRAM.
+
+This is supposed to fulfill two goals:
+
+- Prevent the running U-Boot from being overwritten.
+- Prevent write access to any area that are not actual memory such as
+  memory-mapped devices.
+
+In theory, the LMB feature in U-Boot should fulfill the same goals but
+tests have shown it doesn't handle all cases and seems to be even buggy.
+The present implementation nonetheless adds to the LMB protections and
+actually relies on data structures present only when CONFIG_LMB is
+enabled.
+
+Upstream-Status: Inappropriate [Torizon OS specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ Kconfig   |  7 ++++++
+ fs/fs.c   |  6 +++++
+ lib/lmb.c | 65 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 78 insertions(+)
+
+diff --git a/Kconfig b/Kconfig
+index c35fa239f18..a630a092638 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -747,6 +747,7 @@ config TDX_SECBOOT_HARDENING
+ 	bool "Toradex Secure Boot hardening"
+ 	select TDX_CMD_WHITELIST
+ 	select TDX_BOOTM_PROTECTION
++	select TDX_LOAD_PROTECTION
+ 	select TDX_CLI_PROTECTION
+ 	select TDX_BOOTARGS_PROTECTION
+ 	help
+@@ -780,6 +781,12 @@ config TDX_BOOTM_PROTECTION
+ 	  Enable the protection in bootm to prevent execution of unsigned
+ 	  images.
+ 
++config TDX_LOAD_PROTECTION
++	bool
++	help
++	  Enable the protection in the load command to prevent overwriting
++	  U-Boot itself or writing to memory mapped devices.
++
+ config TDX_CLI_PROTECTION
+ 	bool
+ 	help
+diff --git a/fs/fs.c b/fs/fs.c
+index acf465bdd80..b7ede5068a1 100644
+--- a/fs/fs.c
++++ b/fs/fs.c
+@@ -553,6 +553,12 @@ static int fs_read_lmb_check(const char *filename, ulong addr, loff_t offset,
+ 	lmb_init_and_reserve(&lmb, gd->bd, (void *)gd->fdt_blob);
+ 	lmb_dump_all(&lmb);
+ 
++#if CONFIG_IS_ENABLED(TDX_LOAD_PROTECTION)
++	int tdx_valid_loadaddr(struct lmb *lmb, phys_addr_t base, phys_size_t size);
++	if (!tdx_valid_loadaddr(&lmb, addr, read_len))
++		return -EFAULT;
++#endif
++
+ 	if (lmb_alloc_addr(&lmb, addr, read_len) == addr)
+ 		return 0;
+ 
+diff --git a/lib/lmb.c b/lib/lmb.c
+index f4b8660d2d8..866dabbc95d 100644
+--- a/lib/lmb.c
++++ b/lib/lmb.c
+@@ -12,6 +12,8 @@
+ #include <lmb.h>
+ #include <log.h>
+ #include <malloc.h>
++#include <linux/sizes.h>
++#include <tdx-harden.h>
+ 
+ #include <asm/global_data.h>
+ #include <asm/sections.h>
+@@ -591,3 +593,66 @@ __weak void arch_lmb_reserve(struct lmb *lmb)
+ {
+ 	/* please define platform specific arch_lmb_reserve() */
+ }
++
++#if CONFIG_IS_ENABLED(TDX_LOAD_PROTECTION)
++int tdx_valid_loadaddr(struct lmb *lmb, phys_addr_t base, phys_size_t size)
++{
++	long rgn;
++	phys_addr_t end, off, lim;
++
++	if (!tdx_hardening_enabled())
++		return 1;
++	if (!gd->fdt_blob)
++		return 1;	/* no hardening */
++
++	rgn = lmb_overlaps_region(&lmb->memory, base, size);
++	if (rgn != 0) {
++		debug("Load address range does not overlap first "
++		      "memory region\n");
++		goto err;
++	}
++
++	end = base + size - 1;
++	if (!lmb_addrs_overlap(lmb->memory.region[rgn].base,
++			       lmb->memory.region[rgn].size, base, 1)) {
++		debug("Start address does not fall into memory region\n");
++		goto err;
++	}
++	if (!lmb_addrs_overlap(lmb->memory.region[rgn].base,
++			       lmb->memory.region[rgn].size, end, 1)) {
++		debug("End address does not fall into memory region\n");
++		goto err;
++	}
++
++	/*
++	 * Ensure the end address is within the memory region and below offset
++	 * 1G-64MB / 512M-64MB (on low-memory devices). On a 1GB/512MB device,
++	 * this should give U-Boot 64MB to use at the end of the memory and it
++	 * should be compatible with all Toradex boot scripts.
++	 */
++	off = end - lmb->memory.region[rgn].base;
++	lim = (lmb->memory.region[rgn].size >= SZ_1G) ?
++		(SZ_1G - SZ_64M) : (SZ_512M - SZ_64M);
++
++	debug("Checking offset 0x%llx against limit 0x%llx; "
++	      "memory start: 0x%llx, size: 0x%llx\n",
++	      (u64) off, (u64) lim,
++	      (u64) lmb->memory.region[rgn].base,
++	      (u64) lmb->memory.region[rgn].size);
++
++	if (off >= lim) {
++		debug("End offset (0x%llx) >= limit (0x%llx)\n",
++		      (u64) off, (u64) lim);
++		goto err;
++	}
++
++	debug("Load address 0x%llx, size=0x%llx passed validation\n",
++	      (u64) base, (u64) size);
++	return 1;
++
++err:
++	eprintf("## ERROR: Loading data into addr 0x%llx forbidden by the "
++		"hardening feature\n", (u64) base);
++	return 0;
++}
++#endif
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-k3.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-k3.patch
@@ -1,0 +1,160 @@
+From 7b49995b4b46f8950d754d02932d02c190212755 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Fri, 7 Mar 2025 15:56:56 -0300
+Subject: [PATCH 5/8] toradex: integrate load protection (k3)
+
+This introduces an extra protection to the "load" command. When this
+protection is enabled (by CONFIG_TDX_LOAD_PROTECTION) the command will
+only allow the loading of files in the address range:
+
+- [R0, R0+1G-64M) on devices with at least 1GB of SDRAM.
+- [R0, R0+512M-64M) on devices with less than 1GB of SDRAM.
+
+where R0 stands for the initial address of the SDRAM.
+
+This is supposed to fulfill two goals:
+
+- Prevent the running U-Boot from being overwritten.
+- Prevent write access to any area that are not actual memory such as
+  memory-mapped devices.
+
+In theory, the LMB feature in U-Boot should fulfill the same goals but
+tests have shown it doesn't handle all cases and seems to be even buggy.
+The present implementation nonetheless adds to the LMB protections and
+actually relies on data structures present only when CONFIG_LMB is
+enabled.
+
+Upstream-Status: Inappropriate [Torizon OS specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ Kconfig   |  7 ++++++
+ fs/fs.c   |  6 +++++
+ lib/lmb.c | 65 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 78 insertions(+)
+
+diff --git a/Kconfig b/Kconfig
+index 841db6cdf1b..f687715906f 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -747,6 +747,7 @@ config TDX_SECBOOT_HARDENING
+ 	bool "Toradex Secure Boot hardening"
+ 	select TDX_CMD_WHITELIST
+ 	select TDX_BOOTM_PROTECTION
++	select TDX_LOAD_PROTECTION
+ 	select TDX_CLI_PROTECTION
+ 	select TDX_BOOTARGS_PROTECTION
+ 	help
+@@ -780,6 +781,12 @@ config TDX_BOOTM_PROTECTION
+ 	  Enable the protection in bootm to prevent execution of unsigned
+ 	  images.
+ 
++config TDX_LOAD_PROTECTION
++	bool
++	help
++	  Enable the protection in the load command to prevent overwriting
++	  U-Boot itself or writing to memory mapped devices.
++
+ config TDX_CLI_PROTECTION
+ 	bool
+ 	help
+diff --git a/fs/fs.c b/fs/fs.c
+index acf465bdd80..b7ede5068a1 100644
+--- a/fs/fs.c
++++ b/fs/fs.c
+@@ -553,6 +553,12 @@ static int fs_read_lmb_check(const char *filename, ulong addr, loff_t offset,
+ 	lmb_init_and_reserve(&lmb, gd->bd, (void *)gd->fdt_blob);
+ 	lmb_dump_all(&lmb);
+ 
++#if CONFIG_IS_ENABLED(TDX_LOAD_PROTECTION)
++	int tdx_valid_loadaddr(struct lmb *lmb, phys_addr_t base, phys_size_t size);
++	if (!tdx_valid_loadaddr(&lmb, addr, read_len))
++		return -EFAULT;
++#endif
++
+ 	if (lmb_alloc_addr(&lmb, addr, read_len) == addr)
+ 		return 0;
+ 
+diff --git a/lib/lmb.c b/lib/lmb.c
+index 8bcceb47bd7..a7bd913df13 100644
+--- a/lib/lmb.c
++++ b/lib/lmb.c
+@@ -12,6 +12,8 @@
+ #include <lmb.h>
+ #include <log.h>
+ #include <malloc.h>
++#include <linux/sizes.h>
++#include <tdx-harden.h>
+ 
+ #include <asm/global_data.h>
+ #include <asm/sections.h>
+@@ -598,3 +600,66 @@ __weak void arch_lmb_reserve(struct lmb *lmb)
+ {
+ 	/* please define platform specific arch_lmb_reserve() */
+ }
++
++#if CONFIG_IS_ENABLED(TDX_LOAD_PROTECTION)
++int tdx_valid_loadaddr(struct lmb *lmb, phys_addr_t base, phys_size_t size)
++{
++	long rgn;
++	phys_addr_t end, off, lim;
++
++	if (!tdx_hardening_enabled())
++		return 1;
++	if (!gd->fdt_blob)
++		return 1;	/* no hardening */
++
++	rgn = lmb_overlaps_region(&lmb->memory, base, size);
++	if (rgn != 0) {
++		debug("Load address range does not overlap first "
++		      "memory region\n");
++		goto err;
++	}
++
++	end = base + size - 1;
++	if (!lmb_addrs_overlap(lmb->memory.region[rgn].base,
++			       lmb->memory.region[rgn].size, base, 1)) {
++		debug("Start address does not fall into memory region\n");
++		goto err;
++	}
++	if (!lmb_addrs_overlap(lmb->memory.region[rgn].base,
++			       lmb->memory.region[rgn].size, end, 1)) {
++		debug("End address does not fall into memory region\n");
++		goto err;
++	}
++
++	/*
++	 * Ensure the end address is within the memory region and below offset
++	 * 1G-64MB / 512M-64MB (on low-memory devices). On a 1GB/512MB device,
++	 * this should give U-Boot 64MB to use at the end of the memory and it
++	 * should be compatible with all Toradex boot scripts.
++	 */
++	off = end - lmb->memory.region[rgn].base;
++	lim = (lmb->memory.region[rgn].size >= SZ_1G) ?
++		(SZ_1G - SZ_64M) : (SZ_512M - SZ_64M);
++
++	debug("Checking offset 0x%llx against limit 0x%llx; "
++	      "memory start: 0x%llx, size: 0x%llx\n",
++	      (u64) off, (u64) lim,
++	      (u64) lmb->memory.region[rgn].base,
++	      (u64) lmb->memory.region[rgn].size);
++
++	if (off >= lim) {
++		debug("End offset (0x%llx) >= limit (0x%llx)\n",
++		      (u64) off, (u64) lim);
++		goto err;
++	}
++
++	debug("Load address 0x%llx, size=0x%llx passed validation\n",
++	      (u64) base, (u64) size);
++	return 1;
++
++err:
++	eprintf("## ERROR: Loading data into addr 0x%llx forbidden by the "
++		"hardening feature\n", (u64) base);
++	return 0;
++}
++#endif
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-upstream.patch
@@ -1,0 +1,160 @@
+From 188cbbb319b856a85f90226f74a5738194a565b2 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Fri, 7 Mar 2025 15:56:56 -0300
+Subject: [PATCH 5/8] toradex: integrate load protection (upstream)
+
+This introduces an extra protection to the "load" command. When this
+protection is enabled (by CONFIG_TDX_LOAD_PROTECTION) the command will
+only allow the loading of files in the address range:
+
+- [R0, R0+1G-64M) on devices with at least 1GB of SDRAM.
+- [R0, R0+512M-64M) on devices with less than 1GB of SDRAM.
+
+where R0 stands for the initial address of the SDRAM.
+
+This is supposed to fulfill two goals:
+
+- Prevent the running U-Boot from being overwritten.
+- Prevent write access to any area that are not actual memory such as
+  memory-mapped devices.
+
+In theory, the LMB feature in U-Boot should fulfill the same goals but
+tests have shown it doesn't handle all cases and seems to be even buggy.
+The present implementation nonetheless adds to the LMB protections and
+actually relies on data structures present only when CONFIG_LMB is
+enabled.
+
+Upstream-Status: Inappropriate [Torizon OS specific]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ Kconfig   |  7 ++++++
+ fs/fs.c   |  6 +++++
+ lib/lmb.c | 65 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 78 insertions(+)
+
+diff --git a/Kconfig b/Kconfig
+index 4a4b1005688..1425c764c93 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -761,6 +761,7 @@ config TDX_SECBOOT_HARDENING
+ 	bool "Toradex Secure Boot hardening"
+ 	select TDX_CMD_WHITELIST
+ 	select TDX_BOOTM_PROTECTION
++	select TDX_LOAD_PROTECTION
+ 	select TDX_CLI_PROTECTION
+ 	select TDX_BOOTARGS_PROTECTION
+ 	help
+@@ -794,6 +795,12 @@ config TDX_BOOTM_PROTECTION
+ 	  Enable the protection in bootm to prevent execution of unsigned
+ 	  images.
+ 
++config TDX_LOAD_PROTECTION
++	bool
++	help
++	  Enable the protection in the load command to prevent overwriting
++	  U-Boot itself or writing to memory mapped devices.
++
+ config TDX_CLI_PROTECTION
+ 	bool
+ 	help
+diff --git a/fs/fs.c b/fs/fs.c
+index acf465bdd80..b7ede5068a1 100644
+--- a/fs/fs.c
++++ b/fs/fs.c
+@@ -553,6 +553,12 @@ static int fs_read_lmb_check(const char *filename, ulong addr, loff_t offset,
+ 	lmb_init_and_reserve(&lmb, gd->bd, (void *)gd->fdt_blob);
+ 	lmb_dump_all(&lmb);
+ 
++#if CONFIG_IS_ENABLED(TDX_LOAD_PROTECTION)
++	int tdx_valid_loadaddr(struct lmb *lmb, phys_addr_t base, phys_size_t size);
++	if (!tdx_valid_loadaddr(&lmb, addr, read_len))
++		return -EFAULT;
++#endif
++
+ 	if (lmb_alloc_addr(&lmb, addr, read_len) == addr)
+ 		return 0;
+ 
+diff --git a/lib/lmb.c b/lib/lmb.c
+index 8bcceb47bd7..a7bd913df13 100644
+--- a/lib/lmb.c
++++ b/lib/lmb.c
+@@ -12,6 +12,8 @@
+ #include <lmb.h>
+ #include <log.h>
+ #include <malloc.h>
++#include <linux/sizes.h>
++#include <tdx-harden.h>
+ 
+ #include <asm/global_data.h>
+ #include <asm/sections.h>
+@@ -598,3 +600,66 @@ __weak void arch_lmb_reserve(struct lmb *lmb)
+ {
+ 	/* please define platform specific arch_lmb_reserve() */
+ }
++
++#if CONFIG_IS_ENABLED(TDX_LOAD_PROTECTION)
++int tdx_valid_loadaddr(struct lmb *lmb, phys_addr_t base, phys_size_t size)
++{
++	long rgn;
++	phys_addr_t end, off, lim;
++
++	if (!tdx_hardening_enabled())
++		return 1;
++	if (!gd->fdt_blob)
++		return 1;	/* no hardening */
++
++	rgn = lmb_overlaps_region(&lmb->memory, base, size);
++	if (rgn != 0) {
++		debug("Load address range does not overlap first "
++		      "memory region\n");
++		goto err;
++	}
++
++	end = base + size - 1;
++	if (!lmb_addrs_overlap(lmb->memory.region[rgn].base,
++			       lmb->memory.region[rgn].size, base, 1)) {
++		debug("Start address does not fall into memory region\n");
++		goto err;
++	}
++	if (!lmb_addrs_overlap(lmb->memory.region[rgn].base,
++			       lmb->memory.region[rgn].size, end, 1)) {
++		debug("End address does not fall into memory region\n");
++		goto err;
++	}
++
++	/*
++	 * Ensure the end address is within the memory region and below offset
++	 * 1G-64MB / 512M-64MB (on low-memory devices). On a 1GB/512MB device,
++	 * this should give U-Boot 64MB to use at the end of the memory and it
++	 * should be compatible with all Toradex boot scripts.
++	 */
++	off = end - lmb->memory.region[rgn].base;
++	lim = (lmb->memory.region[rgn].size >= SZ_1G) ?
++		(SZ_1G - SZ_64M) : (SZ_512M - SZ_64M);
++
++	debug("Checking offset 0x%llx against limit 0x%llx; "
++	      "memory start: 0x%llx, size: 0x%llx\n",
++	      (u64) off, (u64) lim,
++	      (u64) lmb->memory.region[rgn].base,
++	      (u64) lmb->memory.region[rgn].size);
++
++	if (off >= lim) {
++		debug("End offset (0x%llx) >= limit (0x%llx)\n",
++		      (u64) off, (u64) lim);
++		goto err;
++	}
++
++	debug("Load address 0x%llx, size=0x%llx passed validation\n",
++	      (u64) base, (u64) size);
++	return 1;
++
++err:
++	eprintf("## ERROR: Loading data into addr 0x%llx forbidden by the "
++		"hardening feature\n", (u64) base);
++	return 0;
++}
++#endif
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/0006-toradex-cmd-fuse-add-switch-for-quiet-operation-down.patch
+++ b/recipes-bsp/u-boot/files/0006-toradex-cmd-fuse-add-switch-for-quiet-operation-down.patch
@@ -1,7 +1,7 @@
-From 3c2e503e27235ca5173d617b0bce74e5468456dd Mon Sep 17 00:00:00 2001
+From f51c5df015ffafad517f4a3322e923f658434e14 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Tue, 18 Feb 2025 15:19:37 -0300
-Subject: [PATCH 5/7] toradex: cmd: fuse: add switch for quiet operation
+Subject: [PATCH 6/8] toradex: cmd: fuse: add switch for quiet operation
  (downstream)
 
 Add switch -q for quiet operation to all fuse subcommands.

--- a/recipes-bsp/u-boot/files/0006-toradex-cmd-fuse-add-switch-for-quiet-operation-upst.patch
+++ b/recipes-bsp/u-boot/files/0006-toradex-cmd-fuse-add-switch-for-quiet-operation-upst.patch
@@ -1,7 +1,7 @@
-From ebe53d4457a4a891a2be29253c8d284ab3a689b5 Mon Sep 17 00:00:00 2001
+From 5d4e677b0b53dcaef17504e9b400211ca12e371b Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Tue, 18 Feb 2025 15:19:37 -0300
-Subject: [PATCH 5/7] toradex: cmd: fuse: add switch for quiet operation
+Subject: [PATCH 6/8] toradex: cmd: fuse: add switch for quiet operation
  (upstream)
 
 Add switch -q for quiet operation to all fuse subcommands.

--- a/recipes-bsp/u-boot/files/0007-toradex-cmd-fuse-add-readv-command-downstream.patch
+++ b/recipes-bsp/u-boot/files/0007-toradex-cmd-fuse-add-readv-command-downstream.patch
@@ -1,7 +1,7 @@
-From 35775bac82c696bfbd007c4f7660ad524deae83f Mon Sep 17 00:00:00 2001
+From f0fe01a592931ca3b281124198014a3a77134c76 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Tue, 18 Feb 2025 16:37:15 -0300
-Subject: [PATCH 6/7] toradex: cmd: fuse: add readv command (upstream)
+Subject: [PATCH 7/8] toradex: cmd: fuse: add readv command (downstream)
 
 Add command "fuse readv" to allow reading fuse values into a
 variable.

--- a/recipes-bsp/u-boot/files/0007-toradex-cmd-fuse-add-readv-command-upstream.patch
+++ b/recipes-bsp/u-boot/files/0007-toradex-cmd-fuse-add-readv-command-upstream.patch
@@ -1,7 +1,7 @@
-From e300bf56339e3b326bd64a945a8c7aabe1dbe6be Mon Sep 17 00:00:00 2001
+From ab761c0b41064447b1dbbd20b7ee0c72e0705f56 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Tue, 18 Feb 2025 16:37:15 -0300
-Subject: [PATCH 6/7] toradex: cmd: fuse: add readv command (downstream)
+Subject: [PATCH 7/8] toradex: cmd: fuse: add readv command (upstream)
 
 Add command "fuse readv" to allow reading fuse values into a
 variable.

--- a/recipes-bsp/u-boot/files/0008-toradex-cmd-setexpr-integrate-protections-downstream.patch
+++ b/recipes-bsp/u-boot/files/0008-toradex-cmd-setexpr-integrate-protections-downstream.patch
@@ -1,7 +1,7 @@
-From d9fa6917727c998b49710bf263fa7296b95d0948 Mon Sep 17 00:00:00 2001
+From c7f8a6e97417fcfa4a284e9365c1fe03e55b5c1c Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 19 Feb 2025 12:05:24 -0300
-Subject: [PATCH 7/7] toradex: cmd: setexpr: integrate protections (downstream)
+Subject: [PATCH 8/8] toradex: cmd: setexpr: integrate protections (downstream)
 
 Prevent usage of the '*' operator when device is closed; this operation
 allows arbitrary memory reads which is an undesirable operation in a

--- a/recipes-bsp/u-boot/files/0008-toradex-cmd-setexpr-integrate-protections-upstream.patch
+++ b/recipes-bsp/u-boot/files/0008-toradex-cmd-setexpr-integrate-protections-upstream.patch
@@ -1,7 +1,7 @@
-From fc07dc19e3da9add6ee10556b55e06f70e65edbf Mon Sep 17 00:00:00 2001
+From 2f01909d455b52fe143e2ac097ee9011074bfcea Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Wed, 19 Feb 2025 12:05:24 -0300
-Subject: [PATCH 7/7] toradex: cmd: setexpr: integrate protections (upstream)
+Subject: [PATCH 8/8] toradex: cmd: setexpr: integrate protections (upstream)
 
 Prevent usage of the '*' operator when device is closed; this operation
 allows arbitrary memory reads which is an undesirable operation in a

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -9,9 +9,10 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM = "\
     file://0002-toradex-integrate-bootm-protection-downstream.patch \
     file://0003-toradex-integrate-CLI-access-protection-downstream.patch \
     file://0004-toradex-integrate-bootargs-protection-downstream.patch \
-    file://0005-toradex-cmd-fuse-add-switch-for-quiet-operation-down.patch \
-    file://0006-toradex-cmd-fuse-add-readv-command-downstream.patch \
-    file://0007-toradex-cmd-setexpr-integrate-protections-downstream.patch \
+    file://0005-toradex-integrate-load-protection-downstream.patch \
+    file://0006-toradex-cmd-fuse-add-switch-for-quiet-operation-down.patch \
+    file://0007-toradex-cmd-fuse-add-readv-command-downstream.patch \
+    file://0008-toradex-cmd-setexpr-integrate-protections-downstream.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_K3 = "\
@@ -20,9 +21,10 @@ TDX_UBOOT_HARDENING_PATCHES_DOWNSTREAM_K3 = "\
     file://0002-toradex-integrate-bootm-protection-downstream.patch \
     file://0003-toradex-integrate-CLI-access-protection-downstream.patch \
     file://0004-toradex-integrate-bootargs-protection-k3.patch \
-    file://0005-toradex-cmd-fuse-add-switch-for-quiet-operation-down.patch \
-    file://0006-toradex-cmd-fuse-add-readv-command-downstream.patch \
-    file://0007-toradex-cmd-setexpr-integrate-protections-downstream.patch \
+    file://0005-toradex-integrate-load-protection-k3.patch \
+    file://0006-toradex-cmd-fuse-add-switch-for-quiet-operation-down.patch \
+    file://0007-toradex-cmd-fuse-add-readv-command-downstream.patch \
+    file://0008-toradex-cmd-setexpr-integrate-protections-downstream.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
@@ -31,9 +33,10 @@ TDX_UBOOT_HARDENING_PATCHES_UPSTREAM = "\
     file://0002-toradex-integrate-bootm-protection-upstream.patch \
     file://0003-toradex-integrate-CLI-access-protection-upstream.patch \
     file://0004-toradex-integrate-bootargs-protection-upstream.patch \
-    file://0005-toradex-cmd-fuse-add-switch-for-quiet-operation-upst.patch \
-    file://0006-toradex-cmd-fuse-add-readv-command-upstream.patch \
-    file://0007-toradex-cmd-setexpr-integrate-protections-upstream.patch \
+    file://0005-toradex-integrate-load-protection-upstream.patch \
+    file://0006-toradex-cmd-fuse-add-switch-for-quiet-operation-upst.patch \
+    file://0007-toradex-cmd-fuse-add-readv-command-upstream.patch \
+    file://0008-toradex-cmd-setexpr-integrate-protections-upstream.patch \
 "
 
 TDX_UBOOT_HARDENING_PATCHES = "${TDX_UBOOT_HARDENING_PATCHES_UPSTREAM}"

--- a/recipes-bsp/u-boot/u-boot-secure-boot.inc
+++ b/recipes-bsp/u-boot/u-boot-secure-boot.inc
@@ -6,9 +6,11 @@ TDX_UBOOT_SECBOOT_PATCHES_COMMON = " \
 
 TDX_UBOOT_SECBOOT_PATCHES_UPSTREAM = " \
     ${TDX_UBOOT_SECBOOT_PATCHES_COMMON} \
+    file://0001-lmb-prevent-alloc-overlap-with-reserved-regions-upst.patch \
     file://0001-toradex-integrate-shared-secboot-module-upstream.patch \
 "
 
+# NOTE: NXP downstream does not need patch "lmb: prevent alloc overlap with reserved regions"
 TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM = " \
     ${TDX_UBOOT_SECBOOT_PATCHES_COMMON} \
     file://0001-toradex-integrate-shared-secboot-module-downstream.patch \
@@ -16,6 +18,7 @@ TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM = " \
 
 TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM_K3 = " \
     ${TDX_UBOOT_SECBOOT_PATCHES_COMMON} \
+    file://0001-lmb-prevent-alloc-overlap-with-reserved-regions-k3.patch \
     file://0001-toradex-add-helper-to-detect-closed-device-k3.patch \
     file://0001-toradex-integrate-shared-secboot-module-downstream.patch \
 "


### PR DESCRIPTION
This introduces two changes:

* Add a new protection to the `load` command to limit to what addresses a file can be loaded to; this is an additional safeguard to the built-in protections in U-Boot (which are buggy by the way) - the corresponding patch is applied only when the hardening is enabled.
* Fix the original built-in protection - the related patch is applied if secure-boot is enabled (whether the hardening is enabled or not); the fix is applied only to NXP upstream and TI downstream U-Boot since a different solution was employed by NXP on their downstream version of U-Boot.

For details see the individual commit messages.

Related-to: TOR-3771
