### PR TITLE
tdx-signed-k3: Add entries for HS-SE tiboot3 on verdin-am62

### DIFF
--- a/classes/tdx-signed-k3-hs-se-tiboot3-verdin-am62.inc
+++ b/classes/tdx-signed-k3-hs-se-tiboot3-verdin-am62.inc
@@ -1,4 +1,6 @@
 # use tiboot3.bin secure boot variant in Tezi
+FIRMWARE_BINARY[0071] = "tiboot3-am62x-hs-verdin.bin"
+FIRMWARE_BINARY[0072] = "tiboot3-am62x-hs-verdin.bin"
 FIRMWARE_BINARY[0073] = "tiboot3-am62x-hs-verdin.bin"
 FIRMWARE_BINARY[0074] = "tiboot3-am62x-hs-verdin.bin"
 FIRMWARE_BINARY[0075] = "tiboot3-am62x-hs-verdin.bin"


### PR DESCRIPTION
Add FIRMWARE_BINARY entries 0071 and 0072 pointing to the HS variant of tiboot3 for Verdin AM62.

The 0071 and 0072 are using HS-FS SoCs since V1.1B and will not use GP SoCs anymore.