### PR TITLE
tdx-signed-harden: disable U-Boot hardening for Aquila AM69

### DIFF
--- a/classes/tdx-signed-harden.inc
+++ b/classes/tdx-signed-harden.inc
@@ -17,6 +17,11 @@ def default_tdx_uboot_hardening_enable(d):
         bb.utils.to_boolean(d.getVar('TDX_IMX_HAB_ENABLE')) and
         bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE'))):
         return True
+    if ('aquila-am69' in d.getVar('OVERRIDES').split(':')):
+        bb.warnonce("Aquila AM69 requires some additional work to have "\
+                "out-of-the-box support for U-Boot hardening, so " \
+                "it is currently disabled by default.")
+        return False
     if ('k3' in d.getVar('OVERRIDES').split(':') and
         bb.utils.to_boolean(d.getVar('TDX_K3_HSSE_ENABLE')) and
         bb.utils.to_boolean(d.getVar('UBOOT_SIGN_ENABLE'))):

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -96,6 +96,7 @@ TDX_SECBOOT_WL_ALLOW_CLOSED_CATEG = "CMD_CAT_ALL_SAFE CMD_CAT_GPIO_CONTROL"
 ### U-Boot hardening / known issues
 
 - On K3 based platforms (Verdin AM62, Aquila AM69), the hardening does not cover the bootloader running on the R5 processor (the boot master); we have plans to evaluate the need for such a protection and implementing it if actually needed.
+- Aquila AM69 requires some additional work to have out-of-the-box support for U-Boot hardening, so it is currently disabled by default.
 
 ## Configuring FIT image signing
 


### PR DESCRIPTION
Booting fails with the following error on Aquila AM69 when U-Boot hardening is enabled:

WARNING: Command execution denied (blocked by category) for `bootflow scan -b`.
ERROR: "bootflow scan -b" returned (code 1) and CLI access is disabled

To improve the user experience when building secure boot-enabled images for Aquila AM69, disable U-Boot hardening for this platform for now.