### PR TITLE
tdx-signed: fix HSSE/HSFS selection

### DIFF
--- a/classes/include/signed/machine/aquila-am69.inc
+++ b/classes/include/signed/machine/aquila-am69.inc
@@ -1,2 +1,2 @@
 # use tiboot3.bin secure boot variant in Tezi
-FIRMWARE_BINARY[0088] = "tiboot3-am69-hs-aquila.bin"
+FIRMWARE_BINARY[0088] := "tiboot3-am69-${SYSFW_SUFFIX}-aquila.bin"

--- a/classes/include/signed/machine/verdin-am62.inc
+++ b/classes/include/signed/machine/verdin-am62.inc
@@ -1,7 +1,7 @@
 # use tiboot3.bin secure boot variant in Tezi
-FIRMWARE_BINARY[0071] = "tiboot3-am62x-hs-verdin.bin"
-FIRMWARE_BINARY[0072] = "tiboot3-am62x-hs-verdin.bin"
-FIRMWARE_BINARY[0073] = "tiboot3-am62x-hs-verdin.bin"
-FIRMWARE_BINARY[0074] = "tiboot3-am62x-hs-verdin.bin"
-FIRMWARE_BINARY[0075] = "tiboot3-am62x-hs-verdin.bin"
-FIRMWARE_BINARY[0076] = "tiboot3-am62x-hs-verdin.bin"
+FIRMWARE_BINARY[0071] := "tiboot3-am62x-${SYSFW_SUFFIX}-verdin.bin"
+FIRMWARE_BINARY[0072] := "tiboot3-am62x-${SYSFW_SUFFIX}-verdin.bin"
+FIRMWARE_BINARY[0073] := "tiboot3-am62x-${SYSFW_SUFFIX}-verdin.bin"
+FIRMWARE_BINARY[0074] := "tiboot3-am62x-${SYSFW_SUFFIX}-verdin.bin"
+FIRMWARE_BINARY[0075] := "tiboot3-am62x-${SYSFW_SUFFIX}-verdin.bin"
+FIRMWARE_BINARY[0076] := "tiboot3-am62x-${SYSFW_SUFFIX}-verdin.bin"

--- a/classes/include/signed/tdx-signed-k3-secboot-tiboot3.inc
+++ b/classes/include/signed/tdx-signed-k3-secboot-tiboot3.inc
@@ -1,2 +1,0 @@
-# build secure variant of tiboot3.bin
-SYSFW_SUFFIX = "hs"

--- a/classes/include/signed/tdx-signed-k3-secboot.inc
+++ b/classes/include/signed/tdx-signed-k3-secboot.inc
@@ -11,8 +11,11 @@ TDX_K3_SECBOOT_KEY_DIR ?= "${TOPDIR}/keys/ti"
 # variable TDX_K3_SECBOOT_TARGET_HSSE_DEVICE:
 TDX_K3_SUPPRESS_HSSE_WARNINGS ?= "0"
 
-# Use secure variant of tiboot3.bin:
-require ${@'tdx-signed-k3-secboot-tiboot3.inc' if bb.utils.to_boolean(d.getVar("TDX_K3_SECBOOT_ENABLE")) and bb.utils.to_boolean(d.getVar("TDX_K3_SECBOOT_TARGET_HSSE_DEVICE")) else ''}
+# Choose between HSSE/HSFS variants of tiboot3.bin:
+def target_hsse(d):
+    return bb.utils.to_boolean(d.getVar('TDX_K3_SECBOOT_ENABLE')) and \
+           bb.utils.to_boolean(d.getVar('TDX_K3_SECBOOT_TARGET_HSSE_DEVICE'))
+SYSFW_SUFFIX := "${@'hs' if target_hsse(d) else 'hs-fs'}"
 
 # Sanity check:
 addhandler validate_k3_secboot_variables


### PR DESCRIPTION
Commit 252bf2e (classes: improve organization of include files) caused a regression on the HSSE/HSFS selection because the include file defining the FIRMWARE_BINARY names was made independent of the variable `TDX_K3_SECBOOT_TARGET_HSSE_DEVICE` (i.e. the binary names were set for HSSE regardless of the image targeting an HSSE device or not). Here we restore the previous/desired behavior.

Related-to: TOR-3835