### PR TITLE
Add OP-TEE support for iMX95 Verdin EVK

### DIFF
--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -73,9 +73,10 @@ validate_optee_support[eventmask] = "bb.event.SanityCheck"
 python validate_optee_support() {
     supported_machines = [
         'aquila-am69',
-        'verdin-imx8mp',
-        'verdin-imx8mm',
+        'imx95-19x19-verdin',
         'verdin-am62',
+        'verdin-imx8mm',
+        'verdin-imx8mp',
     ]
 
     if e.data.getVar('TDX_OPTEE_ENABLE') == '0':

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -9,6 +9,7 @@ TEE might be a good solution to store and manage secrets (e.g. encryption keys) 
 This layer provides support for running OP-TEE on the following SoMs:
 
 - Aquila AM69
+- iMX95 Verdin EVK
 - Verdin AM62
 - Verdin iMX8MP
 - Verdin iMX8MM

--- a/recipes-kernel/linux/linux-optee.inc
+++ b/recipes-kernel/linux/linux-optee.inc
@@ -2,3 +2,10 @@ SRC_URI:append = "\
     file://optee.cfg \
     ${@oe.utils.conditional('TDX_OPTEE_FTPM', '1', 'file://optee-ftpm.cfg', '', d)} \
 "
+
+# Required for iMX95 Verdin EVK when using the NXP BSP layer (meta-imx-bsp),
+# as its kernel recipe uses a custom kernel config fragments implementation
+DELTA_KERNEL_DEFCONFIG:imx95-19x19-verdin += "\
+    optee.cfg \
+    ${@oe.utils.conditional('TDX_OPTEE_FTPM', '1', 'optee-ftpm.cfg', '', d)} \
+"

--- a/recipes-security/optee/include/optee-tdx-imx95-19x19-verdin.inc
+++ b/recipes-security/optee/include/optee-tdx-imx95-19x19-verdin.inc
@@ -1,0 +1,8 @@
+# compatible machine in OP-TEE source code
+OPTEEMACHINE = "imx-mx95evk"
+
+# uart base address (to print debug messages)
+UART_BASE_ADDR = "0x44380000"
+
+# eMMC RPMB partition device node ID
+TDX_OPTEE_FS_RPMB_DEV_ID ?= "0"


### PR DESCRIPTION
Tested using the NXP BSP (meta-imx-bsp).

Validated basic OP-TEE functionality, including trusted applications such as fTPM and PKCS#11.