### PR TITLE
u-boot-harden: fixes for devices having slightly less than 1GB RAM

### DIFF
--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-downstream.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-downstream.patch
@@ -125,13 +125,13 @@ index f4b8660d2d8..866dabbc95d 100644
 +
 +	/*
 +	 * Ensure the end address is within the memory region and below offset
-+	 * 1G-64MB / 512M-64MB (on low-memory devices). On a 1GB/512MB device,
-+	 * this should give U-Boot 64MB to use at the end of the memory and it
-+	 * should be compatible with all Toradex boot scripts.
++	 * 1G-64MB / 512M-64MB (on low-memory devices). This should give U-Boot
++	 * 64MB to use at the end of the memory and it should be compatible with
++	 * all Toradex boot scripts.
 +	 */
 +	off = end - lmb->memory.region[rgn].base;
-+	lim = (lmb->memory.region[rgn].size >= SZ_1G) ?
-+		(SZ_1G - SZ_64M) : (SZ_512M - SZ_64M);
++	lim = min(lmb->memory.region[rgn].size, SZ_1G);
++	lim = max(lim, SZ_64M) - SZ_64M;
 +
 +	debug("Checking offset 0x%llx against limit 0x%llx; "
 +	      "memory start: 0x%llx, size: 0x%llx\n",

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-k3.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-k3.patch
@@ -125,13 +125,13 @@ index 8bcceb47bd7..a7bd913df13 100644
 +
 +	/*
 +	 * Ensure the end address is within the memory region and below offset
-+	 * 1G-64MB / 512M-64MB (on low-memory devices). On a 1GB/512MB device,
-+	 * this should give U-Boot 64MB to use at the end of the memory and it
-+	 * should be compatible with all Toradex boot scripts.
++	 * 1G-64MB / 512M-64MB (on low-memory devices). This should give U-Boot
++	 * 64MB to use at the end of the memory and it should be compatible with
++	 * all Toradex boot scripts.
 +	 */
 +	off = end - lmb->memory.region[rgn].base;
-+	lim = (lmb->memory.region[rgn].size >= SZ_1G) ?
-+		(SZ_1G - SZ_64M) : (SZ_512M - SZ_64M);
++	lim = min(lmb->memory.region[rgn].size, SZ_1G);
++	lim = max(lim, SZ_64M) - SZ_64M;
 +
 +	debug("Checking offset 0x%llx against limit 0x%llx; "
 +	      "memory start: 0x%llx, size: 0x%llx\n",

--- a/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-upstream.patch
+++ b/recipes-bsp/u-boot/files/0005-toradex-integrate-load-protection-upstream.patch
@@ -125,13 +125,13 @@ index 8bcceb47bd7..a7bd913df13 100644
 +
 +	/*
 +	 * Ensure the end address is within the memory region and below offset
-+	 * 1G-64MB / 512M-64MB (on low-memory devices). On a 1GB/512MB device,
-+	 * this should give U-Boot 64MB to use at the end of the memory and it
-+	 * should be compatible with all Toradex boot scripts.
++	 * 1G-64MB / 512M-64MB (on low-memory devices). This should give U-Boot
++	 * 64MB to use at the end of the memory and it should be compatible with
++	 * all Toradex boot scripts.
 +	 */
 +	off = end - lmb->memory.region[rgn].base;
-+	lim = (lmb->memory.region[rgn].size >= SZ_1G) ?
-+		(SZ_1G - SZ_64M) : (SZ_512M - SZ_64M);
++	lim = min(lmb->memory.region[rgn].size, SZ_1G);
++	lim = max(lim, SZ_64M) - SZ_64M;
 +
 +	debug("Checking offset 0x%llx against limit 0x%llx; "
 +	      "memory start: 0x%llx, size: 0x%llx\n",


### PR DESCRIPTION
Change the logic responsible for defining the offset limit of the "load" command (which is part of the self-write protection). The old logic had two hard-coded limits: one that was selected if the device had 1GB of memory (or more) and another for when it had less than 1GB, which was supposed to cover the devices with 512MB of RAM. However, some devices with 1GB of RAM reserve some small amount of memory for particular purposes which causes the old logic to fail by selecting the limit as if the device had 512MB of RAM. This was found to prevent the boot of those devices (particularly some PID4s of the colibri-imx8x). With the new logic the limit is calculated from the available memory as the minimum between the available RAM size and 1GB, minus 64MB.

Related-to: TOR-3830