### PR TITLE
Allow signing bootloader artifacts with SRK2..4 on HABv4

### DIFF
--- a/recipes-bsp/u-boot/files/imx6_imx7_create_csf.sh
+++ b/recipes-bsp/u-boot/files/imx6_imx7_create_csf.sh
@@ -1,24 +1,44 @@
 #!/bin/bash
 
+[ "${XTRACE}" = "1" ] && set -x
+
 set -e
 
+# shellcheck disable=SC2155
 readonly FILE_SCRIPT="$(basename "$0")"
+# shellcheck disable=SC2155
 readonly DIR_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+MACHINE=""
+CSF=""
+TEMPLATE_FILE=""
+
+error() {
+    echo "***"
+    echo " ERROR: ${1}" >&2
+    echo "***"
+    exit 1
+}
+
 help() {
-    if [ -n "${1}" ]; then
-        echo " Error: ${1}"
-    fi
     echo
     echo " Usage: ${DIR_SCRIPT}/${FILE_SCRIPT} <options>"
     echo
     echo " Required Environment Variables:"
     echo
-    echo "    TDX_IMX_HAB_CST_SRK       Path to SRK Table,                e.g. SRK_1_2_3_4_table.bin"
-    echo "    TDX_IMX_HAB_CST_CSF_CERT  Path to CSFK Certificate,         e.g. CSF1_1_sha256_4096_65537_v3_usr_crt.pem"
-    echo "    TDX_IMX_HAB_CST_IMG_CERT  Path to Public key certificate,   e.g. IMG1_1_sha256_4096_65537_v3_usr_crt.pem"
-    echo "    TDX_IMX_HAB_CST_BIN       Path to NXP CST Binary            e.g. cst-3.1.0/release/linux64/bin/cst"
-    echo "    IMXBOOT                   Path to unsigned imx-boot image,  e.g. u-boot.imx"
+    echo "    TDX_IMX_HAB_CST_BIN       Path to NXP CST Binary"
+    echo "                              e.g. cst-3.1.0/release/linux64/bin/cst"
+    echo "    TDX_IMX_HAB_CST_SRK       Path to SRK Table"
+    echo "                              e.g. SRK_1_2_3_4_table.bin"
+    echo "    TDX_IMX_HAB_CST_SRK_CERT  Path to SRK public key certificate"
+    echo "                              e.g. SRK1_sha256_2048_65537_v3_ca_crt.pem (when CA flag is set)"
+    echo "                              e.g. SRK1_sha256_2048_65537_v3_usr_crt.pem (when CA flag is not set)"
+    echo "    TDX_IMX_HAB_CST_CSF_CERT  Path to CSF public key certificate (needed only if CA flag is set for SRK)"
+    echo "                              e.g. CSF1_1_sha256_2048_65537_v3_usr_crt.pem"
+    echo "    TDX_IMX_HAB_CST_IMG_CERT  Path to IMG public key certificate (needed only if CA flag is set for SRK)"
+    echo "                              e.g. IMG1_1_sha256_2048_65537_v3_usr_crt.pem"
+    echo "    IMXBOOT                   Path to unsigned imx-boot image"
+    echo "                              e.g. u-boot.imx"
     echo "    HAB_LOG                   Path to u-boot build log file containing hab info"
     echo
     echo " required arguments:"
@@ -55,15 +75,30 @@ parse_args() {
     done
 }
 
-# Verify environment variable is set and file exists
-verify_env() {
-    if [ -z "$1" ]; then
-        help "Please set environment variable '$2'"
+# Verify that environment variable is set and file exists.
+check_fileref() {
+    local file="${1?file name expected}"
+    local varname="${2?variable name expected}"
+    if [ -z "${file}" ]; then
+        error "Please set environment variable '${varname}'"
     fi
-    if [ ! -f $1 ]; then
-        help "Could not find '$1'"
+    if [ ! -f "${file}" ]; then
+        error "Could not find '${file}' referenced by variable ${varname} (CWD=$(pwd))"
     fi
-	echo "Verified $2=$1"
+    echo "Verified ${varname}=${file}"
+}
+
+# Verify all relevant environment variables.
+validate_environ() {
+    check_fileref "${TDX_IMX_HAB_CST_BIN}" "TDX_IMX_HAB_CST_BIN"
+    check_fileref "${TDX_IMX_HAB_CST_SRK}" "TDX_IMX_HAB_CST_SRK"
+    check_fileref "${TDX_IMX_HAB_CST_SRK_CERT}" "TDX_IMX_HAB_CST_SRK_CERT"
+    if [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
+        check_fileref "${TDX_IMX_HAB_CST_CSF_CERT}" "TDX_IMX_HAB_CST_CSF_CERT"
+        check_fileref "${TDX_IMX_HAB_CST_IMG_CERT}" "TDX_IMX_HAB_CST_IMG_CERT"
+    fi
+    check_fileref "${IMXBOOT}" "IMXBOOT"
+    check_fileref "${HAB_LOG}" "HAB_LOG"
 }
 
 set_template_file() {
@@ -85,41 +120,105 @@ set_template_file() {
 }
 
 generate_csf() {
+    local image_csf="${CSF}.csf"
+
     # Copy template file
-    cp ${DIR_SCRIPT}/${TEMPLATE_FILE} ${CSF}.csf
+    echo "Creating CSF file: ${image_csf}"
+    cp "${DIR_SCRIPT}/${TEMPLATE_FILE}" "${image_csf}"
+
+    # Determine key index (use file name):
+    local kidx
+    kidx=${TDX_IMX_HAB_CST_SRK_CERT##*/}
+    kidx=${kidx##SRK}
+    kidx=${kidx%%_*}
+    if [ "${#kidx}" != 1 ]; then
+        echo "Certificate file name (defined by TDX_IMX_HAB_CST_SRK_CERT) does" \
+             "not match expected pattern - could not determine SRK key index."
+        exit 1
+    fi
+
+    if [ "${kidx}" -ge 1 ] && [ "${kidx}" -le 4 ]; then
+        echo "Using SRK${kidx} for signing."
+    else
+        echo "Bad SRK key index '${kidx}' (inferred from TDX_IMX_HAB_CST_SRK_CERT) - aborting."
+        exit 1
+    fi
+    kidx=$((kidx - 1))
+
+    # Determine whether or not the CA flag was set:
+    local ca
+    if [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
+        ca=1
+    elif [ "${TDX_IMX_HAB_CST_SRK_CERT##*_usr_}" = "crt.pem" ]; then
+        ca=0
+    else
+        echo "Certificate file name (defined by TDX_IMX_HAB_CST_SRK_CERT)" \
+             "does not match expected pattern - could not determine if CA flag is set."
+        exit 1
+    fi
+
+    # Update "Install SRK" section:
+    sed -i "s|@@CST_SRK@@|${TDX_IMX_HAB_CST_SRK}|g" "${image_csf}"
+    sed -i "s|@@CST_KIDX@@|${kidx}|g" "${image_csf}"
+
+    if [ "$ca" = 1 ]; then
+        # Keep "Install CSFK" section and update its contents:
+        sed -i "/#+START_INSTALL_CSFK_BLOCK/d; /#+END_INSTALL_CSFK_BLOCK/d" "${image_csf}"
+        sed -i "s|@@CST_CSF_CERT@@|${TDX_IMX_HAB_CST_CSF_CERT}|g" "${image_csf}"
+        # Delete "Install NOCAK" section:
+        sed -i "/#+START_INSTALL_NOCAK_BLOCK/,/#+END_INSTALL_NOCAK_BLOCK/d" "${image_csf}"
+    else
+        # Delete "Install CSFK" section:
+        sed -i "/#+START_INSTALL_CSFK_BLOCK/,/#+END_INSTALL_CSFK_BLOCK/d" "${image_csf}"
+        # Keep "Install NOCAK" section and update its contents:
+        sed -i "/#+START_INSTALL_NOCAK_BLOCK/d; /#+END_INSTALL_NOCAK_BLOCK/d" "${image_csf}"
+        sed -i "s|@@CST_SRK_CERT@@|${TDX_IMX_HAB_CST_SRK_CERT}|g" "${image_csf}"
+    fi
+
+    # TODO: Consider handling the Unlock section.
+    # if [ "$spl" =  1 ]; then
+    #     # Keep "Unlock" section:
+    #     sed -i "/#+START_UNLOCK_BLOCK/d; /#+END_UNLOCK_BLOCK/d" "${image_csf}"
+    # else
+    #     # Delete "Unlock" section:
+    #     sed -i "/#+START_UNLOCK_BLOCK/,/#+END_UNLOCK_BLOCK/d" "${image_csf}"
+    # fi
+
+    if [ "$ca" = 1 ]; then
+        # Keep "Install Key" section and update its contents:
+        sed -i "/#+START_INSTALL_KEY_BLOCK/d; /#+END_INSTALL_KEY_BLOCK/d" "${image_csf}"
+        sed -i "s|@@CST_IMG_CERT@@|${TDX_IMX_HAB_CST_IMG_CERT}|g" "${image_csf}"
+        # Update part of "Authenticate Data" section:
+        # Verification index is 2 (IMGK slot).
+        sed -i "s|@@CST_AUTH_KIDX@@|2|g" "${image_csf}"
+    else
+        # Delete "Install Key" section
+        sed -i "/#+START_INSTALL_KEY_BLOCK/,/#+END_INSTALL_KEY_BLOCK/d" "${image_csf}"
+        # Update part of "Authenticate Data" section:
+        # Verification index is 0 (SRK slot).
+        sed -i "s|@@CST_AUTH_KIDX@@|0|g" "${image_csf}"
+    fi
 
     # Delete 'Blocks =' section from template
-    sed -i '/Blocks = /d' ${CSF}.csf
-
-    # Update Key Locations
-    sed -i "s|CST_SRK|${TDX_IMX_HAB_CST_SRK}|g" ${CSF}.csf
-    sed -i "s|CST_CSF_CERT|${TDX_IMX_HAB_CST_CSF_CERT}|g" ${CSF}.csf
-    sed -i "s|CST_IMG_CERT|${TDX_IMX_HAB_CST_IMG_CERT}|g" ${CSF}.csf
+    sed -i "/Blocks = /d" "${image_csf}"
 
     # Append Blocks
-    echo "    Blocks = $(grep 'HAB Blocks' ${HAB_LOG} | awk '{print $3, $4, $5}') \"${IMXBOOT}\"" >> ${CSF}.csf
+    echo "    Blocks = $(grep 'HAB Blocks' "${HAB_LOG}" | awk '{print $3, $4, $5}') \"${IMXBOOT}\"" >> "${image_csf}"
 
     # Generate Binary
-    ${TDX_IMX_HAB_CST_BIN} -i ${CSF}.csf -o ${CSF}.bin > ${CSF}.log 2>&1
-    cat ${CSF}.log
+    ${TDX_IMX_HAB_CST_BIN} -i "${image_csf}" -o "${CSF}.bin" > "${CSF}.log" 2>&1
+    cat "${CSF}.log"
 }
 
 parse_args "$@"
 
 # Print command for Yocto logs
-echo $0 "$@"
+echo "$0" "$@"
 
 # Verify required variables
-[ -n "${MACHINE}" ] || help "machine name not specified"
-[ -n "${CSF}" ]     || help "CSF basename not specified"
+[ -n "${MACHINE}" ] || error "machine name not specified"
+[ -n "${CSF}" ]     || error "CSF basename not specified"
 
 set_template_file
-
-verify_env "${TDX_IMX_HAB_CST_SRK}" "TDX_IMX_HAB_CST_SRK"
-verify_env "${TDX_IMX_HAB_CST_CSF_CERT}" "TDX_IMX_HAB_CST_CSF_CERT"
-verify_env "${TDX_IMX_HAB_CST_IMG_CERT}" "TDX_IMX_HAB_CST_IMG_CERT"
-verify_env "${TDX_IMX_HAB_CST_BIN}" "TDX_IMX_HAB_CST_BIN"
-verify_env "${IMXBOOT}" "IMXBOOT"
-verify_env "${HAB_LOG}" "HAB_LOG"
-
+validate_environ
 generate_csf

--- a/recipes-bsp/u-boot/files/imx6_template.csf
+++ b/recipes-bsp/u-boot/files/imx6_template.csf
@@ -8,13 +8,20 @@
 
 [Install SRK]
     # Index of the key location in the SRK table to be installed
-    File = "CST_SRK"
-    Source index = 0
+    File = "@@CST_SRK@@"
+    Source index = @@CST_KIDX@@
 
+#+START_INSTALL_CSFK_BLOCK (present only if CA flag is set)
 [Install CSFK]
     # Key used to authenticate the CSF data
-    File = "CST_CSF_CERT"
+    File = "@@CST_CSF_CERT@@"
 
+#+END_INSTALL_CSFK_BLOCK
+#+START_INSTALL_NOCAK_BLOCK (present only if CA flag is not set)
+[Install NOCAK]
+    File = "@@CST_SRK_CERT@@"
+
+#+END_INSTALL_NOCAK_BLOCK
 [Authenticate CSF]
 
 [Unlock]
@@ -22,16 +29,19 @@
     Engine = CAAM
     Features = MID
 
+#+START_INSTALL_KEY_BLOCK (present only if CA flag is set)
 [Install Key]
     # Key slot index used to authenticate the key to be installed
     Verification index = 0
     # Target key slot in HAB key store where key will be installed
     Target index = 2
     # Key to install
-    File = "CST_IMG_CERT"
+    File = "@@CST_IMG_CERT@@"
 
+#+END_INSTALL_KEY_BLOCK
 [Authenticate Data]
     # Key slot index used to authenticate the image data
-    Verification index = 2
+    Verification index = @@CST_AUTH_KIDX@@
     # Authenticate Start Address, Offset, Length and file
+    # Notice that the following line will be replaced.
     Blocks = 0x7e0fc0 0x1a000 0x2a600 "u-boot-ivt.img"

--- a/recipes-bsp/u-boot/files/imx6ull_template.csf
+++ b/recipes-bsp/u-boot/files/imx6ull_template.csf
@@ -8,25 +8,35 @@
 
 [Install SRK]
     # Index of the key location in the SRK table to be installed
-    File = "CST_SRK"
-    Source index = 0
+    File = "@@CST_SRK@@"
+    Source index = @@CST_KIDX@@
 
+#+START_INSTALL_CSFK_BLOCK (present only if CA flag is set)
 [Install CSFK]
     # Key used to authenticate the CSF data
-    File = "CST_CSF_CERT"
+    File = "@@CST_CSF_CERT@@"
 
+#+END_INSTALL_CSFK_BLOCK
+#+START_INSTALL_NOCAK_BLOCK (present only if CA flag is not set)
+[Install NOCAK]
+    File = "@@CST_SRK_CERT@@"
+
+#+END_INSTALL_NOCAK_BLOCK
 [Authenticate CSF]
 
+#+START_INSTALL_KEY_BLOCK (present only if CA flag is set)
 [Install Key]
     # Key slot index used to authenticate the key to be installed
     Verification index = 0
     # Target key slot in HAB key store where key will be installed
     Target index = 2
     # Key to install
-    File = "CST_IMG_CERT"
+    File = "@@CST_IMG_CERT@@"
 
+#+END_INSTALL_KEY_BLOCK
 [Authenticate Data]
     # Key slot index used to authenticate the image data
-    Verification index = 2
+    Verification index = @@CST_AUTH_KIDX@@
     # Authenticate Start Address, Offset, Length and file
+    # Notice that the following line will be replaced.
     Blocks = 0x7e0fc0 0x1a000 0x2a600 "u-boot.imx"

--- a/recipes-bsp/u-boot/files/imx7_template.csf
+++ b/recipes-bsp/u-boot/files/imx7_template.csf
@@ -8,13 +8,20 @@
 
 [Install SRK]
     # Index of the key location in the SRK table to be installed
-    File = "CST_SRK"
-    Source index = 0
+    File = "@@CST_SRK@@"
+    Source index = @@CST_KIDX@@
 
+#+START_INSTALL_CSFK_BLOCK (present only if CA flag is set)
 [Install CSFK]
     # Key used to authenticate the CSF data
-    File = "CST_CSF_CERT"
+    File = "@@CST_CSF_CERT@@"
 
+#+END_INSTALL_CSFK_BLOCK
+#+START_INSTALL_NOCAK_BLOCK (present only if CA flag is not set)
+[Install NOCAK]
+    File = "@@CST_SRK_CERT@@"
+
+#+END_INSTALL_NOCAK_BLOCK
 [Authenticate CSF]
 
 [Unlock]
@@ -22,16 +29,19 @@
     Engine = CAAM
     Features = MID
 
+#+START_INSTALL_KEY_BLOCK (present only if CA flag is set)
 [Install Key]
     # Key slot index used to authenticate the key to be installed
     Verification index = 0
     # Target key slot in HAB key store where key will be installed
     Target index = 2
     # Key to install
-    File = "CST_IMG_CERT"
+    File = "@@CST_IMG_CERT@@"
 
+#+END_INSTALL_KEY_BLOCK
 [Authenticate Data]
     # Key slot index used to authenticate the image data
-    Verification index = 2
+    Verification index = @@CST_AUTH_KIDX@@
     # Authenticate Start Address, Offset, Length and file
+    # Notice that the following line will be replaced.
     Blocks = 0x7e0fc0 0x1a000 0x2a600 "u-boot.imx"

--- a/recipes-bsp/u-boot/files/imx8m_sign.sh
+++ b/recipes-bsp/u-boot/files/imx8m_sign.sh
@@ -10,15 +10,18 @@ UBOOT_DTB_BINARY="${UBOOT_DTB_BINARY:-u-boot.dtb.out}"
 UBOOT_CONTAINER_BINARY="${UBOOT_CONTAINER_BINARY:-flash.bin}"
 CSF_PREFIX="${CSF_PREFIX:-csf-for-}"
 
+# shellcheck disable=SC2155
 readonly FILE_SCRIPT="$(basename "$0")"
+# shellcheck disable=SC2155
 readonly DIR_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 readonly CSF_SPL="${CSF_PREFIX}spl"
 readonly CSF_FIT="${CSF_PREFIX}fit"
 
 error() {
-    echo "***"
+    echo "***" >&2
     echo " ERROR: ${1}" >&2
-    echo "***"
+    echo "***" >&2
+    exit 1
 }
 
 help() {
@@ -76,11 +79,9 @@ check_fileref() {
     local varname="${2?variable name expected}"
     if [ -z "${file}" ]; then
         error "Please set environment variable '${varname}'"
-        help
     fi
     if [ ! -f "${file}" ]; then
         error "Could not find '${file}' referenced by variable ${varname} (CWD=$(pwd))"
-        exit 1
     fi
     echo "Verified ${varname}=${file}"
 }
@@ -125,7 +126,6 @@ generate_csf_common() {
         exit 1
     fi
 
-    # TODO: Test signing with indices other than 1.
     if [ "${kidx}" -ge 1 ] && [ "${kidx}" -le 4 ]; then
         echo "Using SRK${kidx} for signing."
     else

--- a/recipes-bsp/u-boot/u-boot-hab.inc
+++ b/recipes-bsp/u-boot/u-boot-hab.inc
@@ -47,13 +47,6 @@ imx6_imx7_sign_habv4() {
         bbfatal "Could not find CST binary at ${TDX_IMX_HAB_CST_BIN}."
     fi
 
-    for f in "${TDX_IMX_HAB_CST_SRK}" "${TDX_IMX_HAB_CST_CSF_CERT}" \
-             "${TDX_IMX_HAB_CST_IMG_CERT}" "${TDX_IMX_HAB_CST_SRK_FUSE}"; do
-        if [ ! -e "${f}" ]; then
-            bbfatal "Could not find file '${f}' (required for HAB)."
-        fi
-    done
-
     bbdebug 1 "Generating CSF for U-Boot"
     # Generate CSF file:
     TDX_IMX_HAB_CST_SRK="${TDX_IMX_HAB_CST_SRK}" \
@@ -110,21 +103,6 @@ imx8m_sign_habv4() {
 
     if [ ! -e "${TDX_IMX_HAB_CST_BIN}" ]; then
         bbfatal "Could not find CST binary at ${TDX_IMX_HAB_CST_BIN}."
-    fi
-
-    for f in "${TDX_IMX_HAB_CST_SRK}" "${TDX_IMX_HAB_CST_SRK_CERT}" \
-             "${TDX_IMX_HAB_CST_SRK_FUSE}"; do
-        if [ ! -e "${f}" ]; then
-            bbfatal "Could not find file '${f}' (required for HAB)."
-        fi
-    done
-
-    if [ "${TDX_IMX_HAB_CST_SRK_CA}" = "1" ]; then
-        for f in "${TDX_IMX_HAB_CST_CSF_CERT}" "${TDX_IMX_HAB_CST_IMG_CERT}"; do
-            if [ ! -e "${f}" ]; then
-                bbfatal "Could not find file '${f}' (required for HAB when the CA flag is set)."
-            fi
-        done
     fi
 
     # Save unsigned image

--- a/recipes-bsp/u-boot/u-boot-hab.inc
+++ b/recipes-bsp/u-boot/u-boot-hab.inc
@@ -57,6 +57,7 @@ imx6_imx7_sign_habv4() {
     bbdebug 1 "Generating CSF for U-Boot"
     # Generate CSF file:
     TDX_IMX_HAB_CST_SRK="${TDX_IMX_HAB_CST_SRK}" \
+    TDX_IMX_HAB_CST_SRK_CERT="${TDX_IMX_HAB_CST_SRK_CERT}" \
     TDX_IMX_HAB_CST_CSF_CERT="${TDX_IMX_HAB_CST_CSF_CERT}" \
     TDX_IMX_HAB_CST_IMG_CERT="${TDX_IMX_HAB_CST_IMG_CERT}" \
     TDX_IMX_HAB_CST_BIN="${TDX_IMX_HAB_CST_BIN}" \
@@ -78,6 +79,7 @@ imx6_imx7_sign_habv4() {
     if [ -n "${SPL_BINARY}" ]; then
         bbdebug 1 "Generating CSF for the U-Boot SPL"
         TDX_IMX_HAB_CST_SRK="${TDX_IMX_HAB_CST_SRK}" \
+        TDX_IMX_HAB_CST_SRK_CERT="${TDX_IMX_HAB_CST_SRK_CERT}" \
         TDX_IMX_HAB_CST_CSF_CERT="${TDX_IMX_HAB_CST_CSF_CERT}" \
         TDX_IMX_HAB_CST_IMG_CERT="${TDX_IMX_HAB_CST_IMG_CERT}" \
         TDX_IMX_HAB_CST_BIN="${TDX_IMX_HAB_CST_BIN}" \


### PR DESCRIPTION
This impacts the NXP machines based on i.MX6/6ULL/7 only.

- Add support for signing the bootloader binary with an SRK other than the first one (SRK1).
- Add support for signing with the SRKs only, i.e. without the subordinate keys (corresponding to the NOCAK case offered by NXP) - not tested at the moment but code matches exactly what was done for the i.MX8M where the feature was once tested.

For details, please refer to the commit messages.

The following cases have been tested:

| Machine              |            | Build | Check CSF | hab_status |
| -------------------- | ---------- | ----- | --------- | ---------- |
| colibri-imx6         | CAK/SRK1   | OK    | OK        | OK         |
| colibri-imx6ull-emmc | CAK/SRK1   | OK    | OK        | OK         |
| colibri-imx7-emmc    | CAK/SRK1   | OK    | OK        | OK         |
|                      | CAK/SRK3   | OK    | OK        | OK         |
|                      | NOCAK/SRK1 | OK    | OK        | -          |
