### PR TITLE
Allow signing bootloader artifacts with SRK2..4 on AHAB

### DIFF
--- a/classes/imx-hab.bbclass
+++ b/classes/imx-hab.bbclass
@@ -5,9 +5,10 @@ TDX_IMX_HAB_CST_DIR ?= "${TOPDIR}/keys/cst"
 TDX_IMX_HAB_CST_BIN ?= "${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst"
 
 #
-# Main variables that control the automatic certificate names generation; users
-# will likely want to change these; they should match the answers/parameters
-# given to the CST tool when generating the keys and certificates.
+# Variables that control the automatic certificate names generation; those names
+# are used when signing with the CST tool. Users will likely want to change
+# these; they should match the answers/parameters given to the CST tool when
+# generating the keys and certificates.
 #
 # Explanation:
 #
@@ -21,29 +22,22 @@ TDX_IMX_HAB_CST_BIN ?= "${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst"
 #   named "SRK1_sha256_secp384r1_v3_ca_crt.pem" (found in the certificates
 #   directory) the present variable would be set to "secp384r1".
 #
+# - TDX_IMX_HAB_CST_KEY_EXP: Key exponent for RSA keys (only).
+#
 # - TDX_IMX_HAB_CST_DIG_ALGO: Digest algorithm as entered into the CST tool.
 #
 # - TDX_IMX_HAB_CST_SRK_CA: Whether or not the SRK certificates have the CA flag
 #   set as entered into the CST tool; allowed values are "0" or "1"
 #
+# - TDX_IMX_HAB_CST_KEY_INDEX: Zero-based index of the SRK to be used within the
+#   SRK table.
+#
 TDX_IMX_HAB_CST_CRYPTO    ?= "rsa"
 TDX_IMX_HAB_CST_KEY_SIZE  ?= "2048"
+TDX_IMX_HAB_CST_KEY_EXP   ?= "65537"
 TDX_IMX_HAB_CST_DIG_ALGO  ?= "sha256"
 TDX_IMX_HAB_CST_SRK_CA    ?= "1"
-
-#
-# Secondary parameters for automaticaly generating certificate file names:
-#
-# Explanation:
-#
-# - TDX_IMX_HAB_CST_KEY_INDEX: Zero-based index of the SRK to be used within the
-#   SRK table. NOTE: This is not fully handled yet so it should be set to 0.
-# - TDX_IMX_HAB_CST_KEY_EXP: Key exponent for RSA keys (only).
-#
-
-# TODO: Handle the key index when generating the CSF files for HABv4 and AHAB.
 TDX_IMX_HAB_CST_KEY_INDEX ?= "0"
-TDX_IMX_HAB_CST_KEY_EXP   ?= "65537"
 
 #
 # Helper functions

--- a/classes/imx-hab.bbclass
+++ b/classes/imx-hab.bbclass
@@ -45,6 +45,13 @@ TDX_IMX_HAB_CST_SRK_INDEX ?= "1"
 #
 def make_srk_cert_name(d, basedir):
     """Generate certificate name related to a Super Root Key"""
+
+    # Check use of old variable:
+    if d.getVar('TDX_IMX_HAB_CST_KEY_INDEX'):
+        bb.fatal('Variable TDX_IMX_HAB_CST_KEY_INDEX (range: 0..3) was replaced '
+                 'by TDX_IMX_HAB_CST_SRK_INDEX (now in the range 1..4); please '
+                 'update your configuration.')
+
     res = ""
     crypto = d.getVar("TDX_IMX_HAB_CST_CRYPTO")
     kidx = int(d.getVar("TDX_IMX_HAB_CST_SRK_INDEX"))

--- a/classes/imx-hab.bbclass
+++ b/classes/imx-hab.bbclass
@@ -29,15 +29,16 @@ TDX_IMX_HAB_CST_BIN ?= "${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst"
 # - TDX_IMX_HAB_CST_SRK_CA: Whether or not the SRK certificates have the CA flag
 #   set as entered into the CST tool; allowed values are "0" or "1"
 #
-# - TDX_IMX_HAB_CST_SRK_INDEX: Zero-based index of the SRK to be used within the
-#   SRK table.
+# - TDX_IMX_HAB_CST_SRK_INDEX: Index of the SRK to be used for signing (1..4).
+#   This number decremented by one will be used in the CSF file to select the
+#   proper "Source Index" (which is a 0-based index in the range 0..3).
 #
 TDX_IMX_HAB_CST_CRYPTO    ?= "rsa"
 TDX_IMX_HAB_CST_KEY_SIZE  ?= "2048"
 TDX_IMX_HAB_CST_KEY_EXP   ?= "65537"
 TDX_IMX_HAB_CST_DIG_ALGO  ?= "sha256"
 TDX_IMX_HAB_CST_SRK_CA    ?= "1"
-TDX_IMX_HAB_CST_SRK_INDEX ?= "0"
+TDX_IMX_HAB_CST_SRK_INDEX ?= "1"
 
 #
 # Helper functions
@@ -51,16 +52,16 @@ def make_srk_cert_name(d, basedir):
     ksize = d.getVar("TDX_IMX_HAB_CST_KEY_SIZE")
     caflg = int(d.getVar("TDX_IMX_HAB_CST_SRK_CA"))
     castr = "ca" if caflg != 0 else "usr"
-    if kidx < 0 or kidx > 3:
-        bb.fatal("TDX_IMX_HAB_CST_SRK_INDEX must be in the range [0,3]")
+    if kidx < 1 or kidx > 4:
+        bb.fatal("TDX_IMX_HAB_CST_SRK_INDEX must be in the range [1,4]")
     if crypto == "rsa":
         kexp = d.getVar("TDX_IMX_HAB_CST_KEY_EXP")
-        res = f"SRK{kidx+1}_{dalgo}_{ksize}_{kexp}_v3_{castr}_crt.pem"
+        res = f"SRK{kidx}_{dalgo}_{ksize}_{kexp}_v3_{castr}_crt.pem"
     elif crypto == "ecdsa":
         if ksize.isdigit():
             bb.warn("TDX_IMX_HAB_CST_KEY_SIZE is likely not set correctly;"
                     "check the documentation to understand how to set this variable for ECDSA.")
-        res = f"SRK{kidx+1}_{dalgo}_{ksize}_v3_{castr}_crt.pem"
+        res = f"SRK{kidx}_{dalgo}_{ksize}_v3_{castr}_crt.pem"
     else:
         bb.fatal('TDX_IMX_HAB_CST_CRYPTO is not set correctly'
                  '(its value must be either "rsa" or "ecdsa")')
@@ -76,19 +77,19 @@ def make_sub_cert_name(d, prefix, basedir):
     dalgo = d.getVar("TDX_IMX_HAB_CST_DIG_ALGO")
     ksize = d.getVar("TDX_IMX_HAB_CST_KEY_SIZE")
     caflg = int(d.getVar("TDX_IMX_HAB_CST_SRK_CA"))
-    if kidx < 0 or kidx > 3:
-        bb.fatal("TDX_IMX_HAB_CST_SRK_INDEX must be in the range [0,3]")
+    if kidx < 1 or kidx > 4:
+        bb.fatal("TDX_IMX_HAB_CST_SRK_INDEX must be in the range [1,4]")
     if caflg == 0:
         # Subordinate keys/certs only exist when the SRK cert has the CA flag set.
         pass
     elif crypto == "rsa":
         kexp = d.getVar("TDX_IMX_HAB_CST_KEY_EXP")
-        res = f"{prefix}{kidx+1}_1_{dalgo}_{ksize}_{kexp}_v3_usr_crt.pem"
+        res = f"{prefix}{kidx}_1_{dalgo}_{ksize}_{kexp}_v3_usr_crt.pem"
     elif crypto == "ecdsa":
         if ksize.isdigit():
             bb.warn("TDX_IMX_HAB_CST_KEY_SIZE is likely not set correctly;"
                     "check the documentation to understand how to set this variable for ECDSA.")
-        res = f"{prefix}{kidx+1}_1_{dalgo}_{ksize}_v3_usr_crt.pem"
+        res = f"{prefix}{kidx}_1_{dalgo}_{ksize}_v3_usr_crt.pem"
     else:
         bb.fatal('TDX_IMX_HAB_CST_CRYPTO is not set correctly'
                  '(its value must be either "rsa" or "ecdsa")')

--- a/classes/imx-hab.bbclass
+++ b/classes/imx-hab.bbclass
@@ -29,7 +29,7 @@ TDX_IMX_HAB_CST_BIN ?= "${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst"
 # - TDX_IMX_HAB_CST_SRK_CA: Whether or not the SRK certificates have the CA flag
 #   set as entered into the CST tool; allowed values are "0" or "1"
 #
-# - TDX_IMX_HAB_CST_KEY_INDEX: Zero-based index of the SRK to be used within the
+# - TDX_IMX_HAB_CST_SRK_INDEX: Zero-based index of the SRK to be used within the
 #   SRK table.
 #
 TDX_IMX_HAB_CST_CRYPTO    ?= "rsa"
@@ -37,7 +37,7 @@ TDX_IMX_HAB_CST_KEY_SIZE  ?= "2048"
 TDX_IMX_HAB_CST_KEY_EXP   ?= "65537"
 TDX_IMX_HAB_CST_DIG_ALGO  ?= "sha256"
 TDX_IMX_HAB_CST_SRK_CA    ?= "1"
-TDX_IMX_HAB_CST_KEY_INDEX ?= "0"
+TDX_IMX_HAB_CST_SRK_INDEX ?= "0"
 
 #
 # Helper functions
@@ -46,13 +46,13 @@ def make_srk_cert_name(d, basedir):
     """Generate certificate name related to a Super Root Key"""
     res = ""
     crypto = d.getVar("TDX_IMX_HAB_CST_CRYPTO")
-    kidx = int(d.getVar("TDX_IMX_HAB_CST_KEY_INDEX"))
+    kidx = int(d.getVar("TDX_IMX_HAB_CST_SRK_INDEX"))
     dalgo = d.getVar("TDX_IMX_HAB_CST_DIG_ALGO")
     ksize = d.getVar("TDX_IMX_HAB_CST_KEY_SIZE")
     caflg = int(d.getVar("TDX_IMX_HAB_CST_SRK_CA"))
     castr = "ca" if caflg != 0 else "usr"
     if kidx < 0 or kidx > 3:
-        bb.fatal("TDX_IMX_HAB_CST_KEY_INDEX must be in the range [0,3]")
+        bb.fatal("TDX_IMX_HAB_CST_SRK_INDEX must be in the range [0,3]")
     if crypto == "rsa":
         kexp = d.getVar("TDX_IMX_HAB_CST_KEY_EXP")
         res = f"SRK{kidx+1}_{dalgo}_{ksize}_{kexp}_v3_{castr}_crt.pem"
@@ -72,12 +72,12 @@ def make_sub_cert_name(d, prefix, basedir):
     """Generate certificate name related to a subordinate key"""
     res = ""
     crypto = d.getVar("TDX_IMX_HAB_CST_CRYPTO")
-    kidx = int(d.getVar("TDX_IMX_HAB_CST_KEY_INDEX"))
+    kidx = int(d.getVar("TDX_IMX_HAB_CST_SRK_INDEX"))
     dalgo = d.getVar("TDX_IMX_HAB_CST_DIG_ALGO")
     ksize = d.getVar("TDX_IMX_HAB_CST_KEY_SIZE")
     caflg = int(d.getVar("TDX_IMX_HAB_CST_SRK_CA"))
     if kidx < 0 or kidx > 3:
-        bb.fatal("TDX_IMX_HAB_CST_KEY_INDEX must be in the range [0,3]")
+        bb.fatal("TDX_IMX_HAB_CST_SRK_INDEX must be in the range [0,3]")
     if caflg == 0:
         # Subordinate keys/certs only exist when the SRK cert has the CA flag set.
         pass

--- a/docs/README-secure-boot-imx.md
+++ b/docs/README-secure-boot-imx.md
@@ -28,8 +28,10 @@ After that, configure the various variables listed below to match your choices; 
 | `TDX_IMX_HAB_CST_CERTS_DIR` | Location of the certificates directory. The associated private keys must be located in a directory called `keys` at the same level as the `crts` directory (this is a requirement for the CST tool to work properly). | `${TDX_IMX_HAB_CST_DIR}/crts` |
 | `TDX_IMX_HAB_CST_CRYPTO` | Type of cryptographic keys in use; allowed values: `rsa` or `ecdsa`. This should be set to `ecdsa` if (and only if) you selected "Elliptic Curve Cryptography" when generating the keys/certificates with the CST tool. | `rsa` |
 | `TDX_IMX_HAB_CST_KEY_SIZE` | For **RSA** keys, this would be the key length (in bits) as entered into the CST tool. For **ECDSA**, this would be a string determined from the generated certificate file name; for example, for a file named `SRK1_sha256_secp384r1_v3_ca_crt.pem` (found in the certificates directory) the present variable would be set to `secp384r1`. | `2048` |
+| `TDX_IMX_HAB_CST_KEY_EXP` | Key exponent for RSA keys (only). | `65537` |
 | `TDX_IMX_HAB_CST_DIG_ALGO` | Digest algorithm as entered into the CST tool. | `sha256` |
 | `TDX_IMX_HAB_CST_SRK_CA` | Whether or not the SRK certificates have the CA flag set as entered into the CST tool; allowed values: `0` or `1`. | `1` |
+| `TDX_IMX_HAB_CST_SRK_INDEX` | Index of the SRK to be used for signing within the SRK table; allowed values: `1`..`4`, corresponding to `SRK1`..`SRK4`, respectively. | `1` |
 
 The complete list of variables can be found in the `imx-hab.bbclass` file.
 

--- a/dynamic-layers/freescale/recipes-bsp/imx-mkimage/files/mx8_sign.sh
+++ b/dynamic-layers/freescale/recipes-bsp/imx-mkimage/files/mx8_sign.sh
@@ -1,22 +1,29 @@
 #!/bin/bash
 
+[ "${XTRACE}" = "1" ] && set -x
+
 set -e
 
+# shellcheck disable=SC2155
 readonly FILE_SCRIPT="$(basename "$0")"
+# shellcheck disable=SC2155
 readonly DIR_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+error() {
+    echo "***" >&2
+    echo " ERROR: ${1}" >&2
+    echo "***" >&2
+    exit 1
+}
+
 help() {
-    if [ -n "${1}" ]; then
-        echo
-        echo "***"
-        echo " ERROR: ${1}"
-        echo "***"
-    fi
     echo
     echo " Usage: ${DIR_SCRIPT}/${FILE_SCRIPT} <options>"
     echo
     echo " Required Environment Variables:"
     echo
+    echo "    TDX_IMX_HAB_CST_BIN       Path to NXP CST Binary"
+    echo "                              e.g. cst-3.1.0/release/linux64/bin/cst"
     echo "    TDX_IMX_HAB_CST_SRK       Path to SRK Table"
     echo "                              e.g. SRK_1_2_3_4_table.bin"
     echo "    TDX_IMX_HAB_CST_SRK_CERT  Path to SRK public key certificate"
@@ -24,7 +31,6 @@ help() {
     echo "                              e.g. SRK1_sha256_2048_65537_v3_usr_crt.pem (when CA flag is not set)"
     echo "    TDX_IMX_HAB_CST_SGK_CERT  Path to SGK public key certificate (needed only if CA flag is set for SRK)"
     echo "                              e.g. SGK1_1_sha256_2048_65537_v3_usr_crt.pem"
-    echo "    TDX_IMX_HAB_CST_BIN       Path to NXP CST Binary            e.g. cst-3.1.0/release/linux64/bin/cst"
     echo "    UNSIGNED_IMAGE            Path to unsigned image"
     echo "    LOG_MKIMAGE               Path to mkimage log file"
     echo
@@ -56,81 +62,97 @@ parse_args() {
     done
 }
 
-# Verify environment variable is set and file exists
+# Verify that environment variable is set and file exists.
 check_fileref() {
-    if [ -z "$1" ]; then
-        help "Please set environment variable '$2'"
+    local file="${1?file name expected}"
+    local varname="${2?variable name expected}"
+    if [ -z "${file}" ]; then
+        error "Please set environment variable '${varname}'"
     fi
-    if [ ! -f "$1" ]; then
-        help "Could not find '$1'"
+    if [ ! -f "${file}" ]; then
+        error "Could not find '${file}' referenced by variable ${varname} (CWD=$(pwd))"
     fi
-    echo "Verified $2=$1"
+    echo "Verified ${varname}=${file}"
 }
 
+# Verify all relevant environment variables.
 validate_environ() {
     if [ -z "${TARGET}" ]; then
-        help "target argument required"
+        error "target argument required"
     fi
+    check_fileref "${TDX_IMX_HAB_CST_BIN}" "TDX_IMX_HAB_CST_BIN"
     check_fileref "${TDX_IMX_HAB_CST_SRK}" "TDX_IMX_HAB_CST_SRK"
     check_fileref "${TDX_IMX_HAB_CST_SRK_CERT}" "TDX_IMX_HAB_CST_SRK_CERT"
     if [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
         check_fileref "${TDX_IMX_HAB_CST_SGK_CERT}" "TDX_IMX_HAB_CST_SGK_CERT"
     fi
-    check_fileref "${TDX_IMX_HAB_CST_BIN}" "TDX_IMX_HAB_CST_BIN"
     check_fileref "${UNSIGNED_IMAGE}" "UNSIGNED_IMAGE"
     check_fileref "${LOG_MKIMAGE}" "LOG_MKIMAGE"
 }
 
+# Generate a CSF text file (to be used as input to the CST tool) based on a template.
 generate_csf_ahab() {
     local image_csf="${DIR_SCRIPT}/${TARGET}.csf"
 
-    # Copy template file
+    # Copy template file:
     echo "Creating CSF file: ${image_csf}"
     cp "${DIR_SCRIPT}/mx8_template.csf" "${image_csf}"
 
-    # Get offset from log
-    local header block
-    header=$(grep "CST: CONTAINER 0 offset:" "${LOG_MKIMAGE}" | tail -1 | awk '{print $5}')
-    block=$(grep "CST: CONTAINER 0: Signature Block" "${LOG_MKIMAGE}" | tail -1 | awk '{print $9}')
-
-    # Determine key index (use file name)
+    # Determine key index (use file name):
     local kidx
     kidx=${TDX_IMX_HAB_CST_SRK_CERT##*/}
     kidx=${kidx##SRK}
     kidx=${kidx%%_*}
     if [ "${#kidx}" != 1 ]; then
         echo "Certificate file name (defined by TDX_IMX_HAB_CST_SRK_CERT) does" \
-             "not match expected pattern - could not determine key index."
+             "not match expected pattern - could not determine SRK key index."
+        exit 1
+    fi
+
+    if [ "${kidx}" -ge 1 ] && [ "${kidx}" -le 4 ]; then
+        echo "Using SRK${kidx} for signing."
+    else
+        echo "Bad SRK key index '${kidx}' (inferred from TDX_IMX_HAB_CST_SRK_CERT) - aborting."
         exit 1
     fi
     kidx=$((kidx - 1))
 
-    # Update SRK files
-    sed -i "s|@@CST_SRK@@|${TDX_IMX_HAB_CST_SRK}|g" "${image_csf}"
-    sed -i "s|@@CST_KEY@@|${TDX_IMX_HAB_CST_SRK_CERT}|g" "${image_csf}"
-    sed -i "s|@@CST_KIDX@@|${kidx}|g" "${image_csf}"
-
-    if [ "${TDX_IMX_HAB_CST_SGK_SUPP}" = "0" ] || [ "${TDX_IMX_HAB_CST_SRK_CERT##*_usr_}" = "crt.pem" ]; then
-        # SGK not supported or file name ends with "_usr_crt.pem": an SGK is not expected.
-        # Remove SGK block from CSF.
-        echo "Inferred that CA flag was not set; signing with SRK only."
-        sed -i "/#+START_SGK_BLOCK/,/#+END_SGK_BLOCK/d" "${image_csf}"
-
-    elif [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
-        # File name ends with "_ca_crt.pem": an SGK is expected.
-        local sgk="${TDX_IMX_HAB_CST_SGK_CERT?TDX_IMX_HAB_CST_SGK_CERT must be set}"
-        echo "Inferred that CA flag was set; signing with SRK and SGK."
-        sed -i "/#+START_SGK_BLOCK/d; /#+END_SGK_BLOCK/d" "${image_csf}"
-        sed -i "s|@@CST_SGK@@|${sgk}|g" "${image_csf}"
-
+    # Determine whether or not the CA flag was set:
+    local ca
+    if [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
+        ca=1
+    elif [ "${TDX_IMX_HAB_CST_SRK_CERT##*_usr_}" = "crt.pem" ]; then
+        ca=0
     else
-        # File name does not follow expected pattern.
         echo "Certificate file name (defined by TDX_IMX_HAB_CST_SRK_CERT)" \
              "does not match expected pattern - could not determine if CA flag is set."
         exit 1
     fi
 
-    # Update offset
+    # Update "Install SRK" section:
+    sed -i "s|@@CST_SRK@@|${TDX_IMX_HAB_CST_SRK}|g" "${image_csf}"
+    sed -i "s|@@CST_KEY@@|${TDX_IMX_HAB_CST_SRK_CERT}|g" "${image_csf}"
+    sed -i "s|@@CST_KIDX@@|${kidx}|g" "${image_csf}"
+
+    if [ "$ca" = "0" ] || [ "${TDX_IMX_HAB_CST_SGK_SUPP}" = "0" ]; then
+        # SGK not supported or CA flag is not set: an SGK is not expected.
+        # Remove SGK block from CSF.
+        echo "Inferred that CA flag was not set; signing with SRK only."
+        sed -i "/#+START_SGK_BLOCK/,/#+END_SGK_BLOCK/d" "${image_csf}"
+    else
+        # CA flag is set: an SGK is expected.
+        local sgk="${TDX_IMX_HAB_CST_SGK_CERT?TDX_IMX_HAB_CST_SGK_CERT must be set}"
+        echo "Inferred that CA flag was set; signing with SRK and SGK."
+        sed -i "/#+START_SGK_BLOCK/d; /#+END_SGK_BLOCK/d" "${image_csf}"
+        sed -i "s|@@CST_SGK@@|${sgk}|g" "${image_csf}"
+    fi
+
+    # Get offset from log:
+    local header block
+    header=$(grep "CST: CONTAINER 0 offset:" "${LOG_MKIMAGE}" | tail -1 | awk '{print $5}')
+    block=$(grep "CST: CONTAINER 0: Signature Block" "${LOG_MKIMAGE}" | tail -1 | awk '{print $9}')
+
+    # Update offset:
     sed -i "s|@@FLASH.BIN@@|${UNSIGNED_IMAGE}|g" "${image_csf}"
     sed -i "s|@@OFFSETS_ROW:.*$|Offsets = ${header} ${block}|g" "${image_csf}"
 
@@ -138,7 +160,7 @@ generate_csf_ahab() {
     echo "Tool location: '${TDX_IMX_HAB_CST_BIN}'"
     echo "CSF location: '${image_csf}'"
 
-    # Sign
+    # Sign:
     "${TDX_IMX_HAB_CST_BIN}" -i "${image_csf}" -o "${UNSIGNED_IMAGE}-signed"
 }
 


### PR DESCRIPTION
The feature to allow signing with an SRK index other than 1 was actually already working with AHAB (from a previous implementation), but it had never been tested. However, here I took the opportunity to sync the signing script with the one for the i.MX8M which brought a few improvements to AHAB as well.

In summary this PR is adding a few non-functional improvements to the signing script and updating the documentation regarding the new variable `TDX_IMX_HAB_CST_SRK_INDEX` (the one allowing the selection of the SRK index). Btw, this variable was renamed from the previous implementation (where the variable wasn't documented yet). Anyways, I added a check to throw a fatal error in case the old variable is set.

Please see the individual commit messages for details.

This has been tested with the following configurations:

| Machine       |            | Build | Check CSF | ahab_status |
|---------------|------------|-------|-----------|-------------|
| colibri-imx8x | CAK/SRK1   | OK    | OK        | OK          |
|               | CAK/SRK3   | OK    | OK        | OK          |
|               | NOCAK/SRK2 | OK    | OK        | OK          |
