### PR TITLE
Attempt to fix error "Customer key cannot be found" when building signed verdin-am62 images

### DIFF
--- a/dynamic-layers/meta-ti-bsp/recipes-ti/secdev/ti-k3-secdev-secboot.inc
+++ b/dynamic-layers/meta-ti-bsp/recipes-ti/secdev/ti-k3-secdev-secboot.inc
@@ -1,6 +1,7 @@
 update_signing_keys() {
-    rm -Rf ${S}/keys
-    ln -s ${TDX_K3_SECBOOT_KEY_DIR} ${S}/keys
+    echo "Updating signing keys directory '${S}/keys'"
+    rm -Rf "${S}/keys"
+    cp -rv ${TDX_K3_SECBOOT_KEY_DIR} "${S}/keys"
 }
 
 do_unpack:append() {

--- a/recipes-bsp/u-boot/u-boot-k3-secboot.inc
+++ b/recipes-bsp/u-boot/u-boot-k3-secboot.inc
@@ -1,6 +1,7 @@
 update_signing_keys() {
-    rm -Rf ${S}/arch/arm/mach-k3/keys
-    ln -s ${TDX_K3_SECBOOT_KEY_DIR} ${S}/arch/arm/mach-k3/keys
+    echo "Updating signing keys directory '${S}/arch/arm/mach-k3/keys'"
+    rm -Rf "${S}/arch/arm/mach-k3/keys"
+    cp -rv "${TDX_K3_SECBOOT_KEY_DIR}" "${S}/arch/arm/mach-k3/keys"
 }
 
 do_unpack:append() {


### PR DESCRIPTION
This is an attempt to solve a build failure happening on Jenkins in which the logs show this:

> Error: Customer key cannot be found, correctly define TI_SECURE_DEV_PKG
> environment variable

Originally the code was creating a symlink from the source directory to the keys directory passed by the user which ended up creating a sysroot with symlinks pointing outside the sysroot. Normally a sysroot is expected to be a self-contained environment, thus having such symlinks would not be ideal.

With this commit we copy the key files directory into the source directory which in turn makes the sysroot self contained. The hypothesis is that the external symlinks could be causing issues with the sstate mechanism and removing them would solve the issue in CI. However, this must be confirmed since the issue in CI couldn't be reproduced locally.

Related-to: TOR-3840

Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>