### PR TITLE
u-boot: show CST output upon errors

### DIFF
--- a/recipes-bsp/u-boot/files/imx6_imx7_create_csf.sh
+++ b/recipes-bsp/u-boot/files/imx6_imx7_create_csf.sh
@@ -14,9 +14,9 @@ CSF=""
 TEMPLATE_FILE=""
 
 error() {
-    echo "***"
+    echo "***" >&2
     echo " ERROR: ${1}" >&2
-    echo "***"
+    echo "***" >&2
     exit 1
 }
 
@@ -105,17 +105,17 @@ set_template_file() {
     case ${MACHINE} in
         "IMX6ULL")
             TEMPLATE_FILE="imx6ull_template.csf"
-	    ;;
-	"IMX7")
-	    TEMPLATE_FILE="imx7_template.csf"
-	    ;;
-	"IMX6")
+            ;;
+        "IMX7")
+            TEMPLATE_FILE="imx7_template.csf"
+            ;;
+        "IMX6")
             TEMPLATE_FILE="imx6_template.csf"
-	    ;;
+            ;;
         *)
-	    echo "Invalid SoC!"
-	    return 1
-	    ;;
+            echo "Invalid SoC!"
+            return 1
+            ;;
     esac
 }
 
@@ -206,7 +206,11 @@ generate_csf() {
     echo "    Blocks = $(grep 'HAB Blocks' "${HAB_LOG}" | awk '{print $3, $4, $5}') \"${IMXBOOT}\"" >> "${image_csf}"
 
     # Generate Binary
-    ${TDX_IMX_HAB_CST_BIN} -i "${image_csf}" -o "${CSF}.bin" > "${CSF}.log" 2>&1
+    if ! ${TDX_IMX_HAB_CST_BIN} -i "${image_csf}" -o "${CSF}.bin" > "${CSF}.log" 2>&1; then
+        echo "CST execution log:" >&2
+        cat "${CSF}.log" | sed 's@^@|@' >&2
+        error "CST failed to execute; please check logs."
+    fi
     cat "${CSF}.log"
 }
 

--- a/recipes-bsp/u-boot/files/imx8m_sign.sh
+++ b/recipes-bsp/u-boot/files/imx8m_sign.sh
@@ -209,7 +209,11 @@ generate_spl_csf_and_update_container() {
     sed -i "/Blocks = / s@.*@    Blocks = ${spl_block_base} 0x0 ${spl_block_size} \"${UBOOT_CONTAINER_BINARY}\"@" "${CSF_SPL}.csf"
 
     # Generate CSF blob:
-    "${TDX_IMX_HAB_CST_BIN}" -i "${CSF_SPL}.csf" -o "${CSF_SPL}.bin" > "${CSF_SPL}.log" 2>&1
+    if ! "${TDX_IMX_HAB_CST_BIN}" -i "${CSF_SPL}.csf" -o "${CSF_SPL}.bin" > "${CSF_SPL}.log" 2>&1; then
+        echo "CST execution log:" >&2
+        cat "${CSF_SPL}.log" | sed 's@^@|@' >&2
+        error "CST failed to execute; please check logs."
+    fi
     cat "${CSF_SPL}.log"
 
     # Patch CSF blob into flash.bin:
@@ -274,7 +278,11 @@ generate_fit_csf_and_update_container() {
     dd if=ivt.bin of="${UBOOT_CONTAINER_BINARY}" bs=1 seek=${ivt_block_offset} conv=notrunc
 
     # Generate CSF blob:
-    "${TDX_IMX_HAB_CST_BIN}" -i "${CSF_FIT}.csf" -o "${CSF_FIT}.bin" > "${CSF_FIT}.log" 2>&1
+    if ! "${TDX_IMX_HAB_CST_BIN}" -i "${CSF_FIT}.csf" -o "${CSF_FIT}.bin" > "${CSF_FIT}.log" 2>&1; then
+        echo "CST execution log:" >&2
+        cat "${CSF_FIT}.log" | sed 's@^@|@' >&2
+        error "CST failed to execute; please check logs."
+    fi
     cat "${CSF_FIT}.log"
 
     # Comment from doc/imx/habv4/csf_examples/mx8m/csf.sh:


### PR DESCRIPTION
Previously when CST failed to execute no error messages were available in the task log which made hard for users to figure out the reason of the failure. With this commit we dump the output of the tool execution to improve the situation.