### PR TITLE
u-boot-hab.inc: use libfaketime when generating CSF binaries

### DIFF
--- a/docs/README-secure-boot-imx.md
+++ b/docs/README-secure-boot-imx.md
@@ -35,6 +35,8 @@ After that, configure the various variables listed below to match your choices; 
 
 The complete list of variables can be found in the `imx-hab.bbclass` file.
 
+**NOTE**: For HAB signing, [libfaketime](https://github.com/wolfcw/libfaketime) is used when generating the CSF binaries with CST in order to create reproducible bootloader image builds.
+
 ### Known issues
 
 - Starting from version 4.0.0, the NXP CST tool may not work as expected on older Linux distributions (e.g., Ubuntu 20.04). If you are using NXP CST 4.0.0 or later, it is recommended to use a more recent Linux distribution (e.g., Ubuntu 24.04) to ensure compatibility and avoid potential issues.

--- a/recipes-bsp/u-boot/files/imx6_imx7_create_csf.sh
+++ b/recipes-bsp/u-boot/files/imx6_imx7_create_csf.sh
@@ -12,6 +12,12 @@ readonly DIR_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 &&
 MACHINE=""
 CSF=""
 TEMPLATE_FILE=""
+LIBFAKETIME_PATH="${LIBFAKETIME_PATH}"
+
+# Timestamp to be used by libfaketime. The date itself isn't important, but this needs
+# to be constant between builds in order to generate deterministic CSF binaries
+# Default value is: November 6, 2024 (12:00 PM UTC)
+FAKETIME=${FAKETIME:-1730894400}
 
 error() {
     echo "***" >&2
@@ -40,6 +46,11 @@ help() {
     echo "    IMXBOOT                   Path to unsigned imx-boot image"
     echo "                              e.g. u-boot.imx"
     echo "    HAB_LOG                   Path to u-boot build log file containing hab info"
+    echo
+    echo " Optional Environment Variables:"
+    echo
+    echo "    LIBFAKETIME_PATH          Path to libfaketime library (needed for reproducible CSF binary builds)"
+    echo "                              default: unset"
     echo
     echo " required arguments:"
     echo "    -m --machine              target SoC (i.e IMX6, IMX7, IMX6ULL)"
@@ -206,7 +217,11 @@ generate_csf() {
     echo "    Blocks = $(grep 'HAB Blocks' "${HAB_LOG}" | awk '{print $3, $4, $5}') \"${IMXBOOT}\"" >> "${image_csf}"
 
     # Generate Binary
-    if ! ${TDX_IMX_HAB_CST_BIN} -i "${image_csf}" -o "${CSF}.bin" > "${CSF}.log" 2>&1; then
+    if ! env ${LIBFAKETIME_PATH+LD_PRELOAD="${LIBFAKETIME_PATH}"
+                                FAKETIME_FMT="%s"
+                                FAKETIME="@${FAKETIME}"} \
+             "${TDX_IMX_HAB_CST_BIN}" -i "${image_csf}" -o "${CSF}.bin" > "${CSF}.log" 2>&1
+    then
         echo "CST execution log:" >&2
         cat "${CSF}.log" | sed 's@^@|@' >&2
         error "CST failed to execute; please check logs."

--- a/recipes-bsp/u-boot/files/imx8m_sign.sh
+++ b/recipes-bsp/u-boot/files/imx8m_sign.sh
@@ -9,6 +9,12 @@ UBOOT_SPL_DDR_BINARY="${UBOOT_SPL_DDR_BINARY:-u-boot-spl-ddr.bin}"
 UBOOT_DTB_BINARY="${UBOOT_DTB_BINARY:-u-boot.dtb.out}"
 UBOOT_CONTAINER_BINARY="${UBOOT_CONTAINER_BINARY:-flash.bin}"
 CSF_PREFIX="${CSF_PREFIX:-csf-for-}"
+LIBFAKETIME_PATH="${LIBFAKETIME_PATH}"
+
+# Timestamp to be used by libfaketime. The date itself isn't important, but this needs
+# to be constant between builds in order to generate deterministic CSF binaries
+# Default value is: November 6, 2024 (12:00 PM UTC)
+FAKETIME=${FAKETIME:-1730894400}
 
 # shellcheck disable=SC2155
 readonly FILE_SCRIPT="$(basename "$0")"
@@ -52,6 +58,8 @@ help() {
     echo "                              default: flash.bin"
     echo "    CSF_PREFIX                Prefix for CSF files to be produced"
     echo "                              default: csf-for-"
+    echo "    LIBFAKETIME_PATH          Path to libfaketime library (needed for reproducible CSF binary builds)"
+    echo "                              default: unset"
     echo
     echo " Optional switches:"
     echo "    -h --help            display this Help message"
@@ -209,7 +217,11 @@ generate_spl_csf_and_update_container() {
     sed -i "/Blocks = / s@.*@    Blocks = ${spl_block_base} 0x0 ${spl_block_size} \"${UBOOT_CONTAINER_BINARY}\"@" "${CSF_SPL}.csf"
 
     # Generate CSF blob:
-    if ! "${TDX_IMX_HAB_CST_BIN}" -i "${CSF_SPL}.csf" -o "${CSF_SPL}.bin" > "${CSF_SPL}.log" 2>&1; then
+    if ! env ${LIBFAKETIME_PATH+LD_PRELOAD="${LIBFAKETIME_PATH}"
+                                FAKETIME_FMT="%s"
+                                FAKETIME="@${FAKETIME}"} \
+             "${TDX_IMX_HAB_CST_BIN}" -i "${CSF_SPL}.csf" -o "${CSF_SPL}.bin" > "${CSF_SPL}.log" 2>&1
+    then
         echo "CST execution log:" >&2
         cat "${CSF_SPL}.log" | sed 's@^@|@' >&2
         error "CST failed to execute; please check logs."
@@ -278,7 +290,11 @@ generate_fit_csf_and_update_container() {
     dd if=ivt.bin of="${UBOOT_CONTAINER_BINARY}" bs=1 seek=${ivt_block_offset} conv=notrunc
 
     # Generate CSF blob:
-    if ! "${TDX_IMX_HAB_CST_BIN}" -i "${CSF_FIT}.csf" -o "${CSF_FIT}.bin" > "${CSF_FIT}.log" 2>&1; then
+    if ! env ${LIBFAKETIME_PATH+LD_PRELOAD="${LIBFAKETIME_PATH}"
+                                FAKETIME_FMT="%s"
+                                FAKETIME="@${FAKETIME}"} \
+             "${TDX_IMX_HAB_CST_BIN}" -i "${CSF_FIT}.csf" -o "${CSF_FIT}.bin" > "${CSF_FIT}.log" 2>&1
+    then
         echo "CST execution log:" >&2
         cat "${CSF_FIT}.log" | sed 's@^@|@' >&2
         error "CST failed to execute; please check logs."

--- a/recipes-bsp/u-boot/u-boot-hab.inc
+++ b/recipes-bsp/u-boot/u-boot-hab.inc
@@ -6,6 +6,9 @@ DEPENDS += "util-linux-native"
 # Need this for the xxd and fdtget utilities used by imx8m_sign.sh
 DEPENDS += "xxd-native dtc-native"
 
+# Need this to create deterministic CSF binaries when running the NXP Code Signing Tool
+DEPENDS += "libfaketime-native"
+
 SRC_URI:append = "\
     file://u-boot-hab.cfg \
     file://create_fuse_cmds.sh \
@@ -49,6 +52,7 @@ imx6_imx7_sign_habv4() {
 
     bbdebug 1 "Generating CSF for U-Boot"
     # Generate CSF file:
+    LIBFAKETIME_PATH="${STAGING_LIBDIR_NATIVE}/faketime/libfaketime.so.1" \
     TDX_IMX_HAB_CST_SRK="${TDX_IMX_HAB_CST_SRK}" \
     TDX_IMX_HAB_CST_SRK_CERT="${TDX_IMX_HAB_CST_SRK_CERT}" \
     TDX_IMX_HAB_CST_CSF_CERT="${TDX_IMX_HAB_CST_CSF_CERT}" \
@@ -71,6 +75,7 @@ imx6_imx7_sign_habv4() {
     # Repeat the process for SPL if SPL was also built.
     if [ -n "${SPL_BINARY}" ]; then
         bbdebug 1 "Generating CSF for the U-Boot SPL"
+        LIBFAKETIME_PATH="${STAGING_LIBDIR_NATIVE}/faketime/libfaketime.so.1" \
         TDX_IMX_HAB_CST_SRK="${TDX_IMX_HAB_CST_SRK}" \
         TDX_IMX_HAB_CST_SRK_CERT="${TDX_IMX_HAB_CST_SRK_CERT}" \
         TDX_IMX_HAB_CST_CSF_CERT="${TDX_IMX_HAB_CST_CSF_CERT}" \
@@ -109,6 +114,7 @@ imx8m_sign_habv4() {
     cp "flash.bin" "flash.bin-unsigned"
 
     # Sign the bootloader container (in-place)
+    LIBFAKETIME_PATH="${STAGING_LIBDIR_NATIVE}/faketime/libfaketime.so.1" \
     TDX_IMX_HAB_CST_SRK="${TDX_IMX_HAB_CST_SRK}" \
     TDX_IMX_HAB_CST_SRK_CERT="${TDX_IMX_HAB_CST_SRK_CERT}" \
     TDX_IMX_HAB_CST_CSF_CERT="${TDX_IMX_HAB_CST_CSF_CERT}" \

--- a/recipes-test/libfaketime/libfaketime_%.bbappend
+++ b/recipes-test/libfaketime/libfaketime_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "native"


### PR DESCRIPTION
When generating the CSF binaries, the NXP Code Signing Tool adds the current UTC timestamp in string format to them, resulting in files that are not reproducible. It is possible to circumvent this limitation by using a library like libfaketime during the build process to trick CST to always add the same timestamp to the binaries.

Related-to: TOR-3842