### PR TITLE
u-boot-harden: disable unsupported bootmeths by default

### DIFF
--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -74,7 +74,7 @@ The hardening features are controlled by the variables in the following table pl
 | `TDX_SECBOOT_REQUIRED_BOOTARGS` | Expected value for the fixed part of the kernel command line | Different value for each machine |
 | `TDX_AMEND_BOOT_SCRIPT` | When set to `1` the boot script will be amended to make it suitable for secure boot; this only works with the script provided by Toradex for BSP reference images; users employing a custom script should set this to `0` | Same value as variable `TDX_UBOOT_HARDENING_ENABLE` |
 | `TDX_CHECK_UNSUPP_BOOTMETH` | Enable a build-time check to determine if an unsupported [bootmeth](https://docs.u-boot.org/en/stable/develop/bootstd/overview.html#bootmeth) is being enabled in U-Boot (which could become an attack vector). | `1` |
-| `TDX_DISABLE_UNSUPP_BOOTMETH`| Enable a config fragment in U-Boot to disable unsupported bootmeths; relevant only if the machine is using [Standard Boot](https://docs.u-boot.org/en/stable/develop/bootstd/index.html). | Different value for each machine |
+| `TDX_DISABLE_UNSUPP_BOOTMETH`| Enable a config fragment in U-Boot to disable unsupported bootmeths; relevant only if the machine is using [Standard Boot](https://docs.u-boot.org/en/stable/develop/bootstd/index.html). | `1` |
 
 ### U-Boot hardening / whitelist setup
 

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -141,7 +141,7 @@ check_dotconfig_compat() {
     fi
 }
 
-TDX_DISABLE_UNSUPP_BOOTMETH ?= "0"
+TDX_DISABLE_UNSUPP_BOOTMETH ?= "1"
 SRC_URI:append = "\
     ${@oe.utils.conditional('TDX_DISABLE_UNSUPP_BOOTMETH', '1', 'file://disable-bootmeths.cfg', '', d)} \
 "


### PR DESCRIPTION
Set default value of TDX_DISABLE_UNSUPP_BOOTMETH from "0" to "1" to avoid breaking the build on machines that are already enabling "Standard Boot" intentionally or not.

Related-to: TOR-3865
