### PR TITLE
Enable the hardening features on the aquila-am69

### DIFF
--- a/classes/include/signed/tdx-signed-harden.inc
+++ b/classes/include/signed/tdx-signed-harden.inc
@@ -13,7 +13,7 @@
 # UBOOT_SIGN_ENABLE are set, by default.
 #
 def default_tdx_uboot_hardening_enable(d):
-    unsupported_machines = ["aquila-am69", "imx95-19x19-verdin"]
+    unsupported_machines = ["imx95-19x19-verdin"]
     for machine in unsupported_machines:
         if (machine in d.getVar('OVERRIDES').split(':')):
             bb.warnonce("%s machine requires some additional work to have "\


### PR DESCRIPTION
With "Standard Boot" being now supported by the hardening, in particular the "bootflow" command used by newer Toradex modules such as the aquila-am69, enable the hardening on that SoM.

Related-to: TOR-3886
