### PR TITLE
WIP: Add OP-TEE support for Colibri iMX8X and Apalis iMX8

### DIFF
--- a/classes/include/optee/machine/apalis-imx8.inc
+++ b/classes/include/optee/machine/apalis-imx8.inc
@@ -1,0 +1,23 @@
+# extension to append to optee binary
+OPTEE_BIN_EXT = "bin"
+
+# OP-TEE boot images to be deployed
+OPTEE_BOOT_IMAGE:forcevariable = "tee.bin uTee-${OPTEE_BIN_EXT}"
+
+# OP-TEE load address
+TDX_OPTEE_ADDR_LOAD = "0xB0000000"
+
+# OP-TEE reserved memory
+#TDX_OPTEE_ADDR_SIZE ?= "0x1000000"
+TDX_OPTEE_ADDR_SIZE ?= "0x2000000"
+
+#DEPLOY_OPTEE:forcevariable = "false"
+#ATF_MACHINE_NAME:forcevariable = "bl31-${ATF_PLATFORM}.bin"
+MACHINE_FEATURES:remove:pn-imx-boot = "optee"
+#DEPLOY_OPTEE:pn-imx-boot:forcevariable = "false"
+
+# add OP-TEE nodes to kernel device tree
+require classes/include/optee/linux-dt-overlay.inc
+
+# additional configuration if booting from FIT image
+require ${@oe.utils.conditional('KERNEL_IMAGETYPE', 'fitImage', 'classes/include/optee/boot-from-fit.inc', '', d)}

--- a/classes/include/optee/machine/colibri-imx8x.inc
+++ b/classes/include/optee/machine/colibri-imx8x.inc
@@ -1,0 +1,22 @@
+# extension to append to optee binary
+OPTEE_BIN_EXT = "bin"
+
+# OP-TEE boot images to be deployed
+OPTEE_BOOT_IMAGE:forcevariable = "tee.bin uTee-${OPTEE_BIN_EXT}"
+
+# OP-TEE load address
+TDX_OPTEE_ADDR_LOAD = "0xA0000000"
+
+# OP-TEE reserved memory
+TDX_OPTEE_ADDR_SIZE ?= "0x1000000"
+
+#DEPLOY_OPTEE:forcevariable = "false"
+#ATF_MACHINE_NAME:forcevariable = "bl31-${ATF_PLATFORM}.bin"
+MACHINE_FEATURES:remove:pn-imx-boot = "optee"
+#DEPLOY_OPTEE:pn-imx-boot:forcevariable = "false"
+
+# add OP-TEE nodes to kernel device tree
+require classes/include/optee/linux-dt-overlay.inc
+
+# additional configuration if booting from FIT image
+require ${@oe.utils.conditional('KERNEL_IMAGETYPE', 'fitImage', 'classes/include/optee/boot-from-fit.inc', '', d)}

--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -76,9 +76,11 @@ validate_optee_support[eventmask] = "bb.event.SanityCheck"
 python validate_optee_support() {
     supported_machines = [
         'apalis-imx6',
+        'apalis-imx8',
         'aquila-am69',
         'colibri-imx6',
         'colibri-imx7-emmc',
+        'colibri-imx8x',
         'imx95-19x19-verdin',
         'verdin-am62',
         'verdin-imx8mm',

--- a/recipes-bsp/u-boot/u-boot-distro-boot-optee.inc
+++ b/recipes-bsp/u-boot/u-boot-distro-boot-optee.inc
@@ -9,6 +9,8 @@ setenv kernel_addr_r ${tee_addr_r}; \
 bootm"
 KERNEL_BOOTCMD:mx6-generic-bsp = "${KERNEL_BOOTCMD_OPTEE}"
 KERNEL_BOOTCMD:mx7-generic-bsp = "${KERNEL_BOOTCMD_OPTEE}"
+KERNEL_BOOTCMD:colibri-imx8x = "${KERNEL_BOOTCMD_OPTEE}"
+KERNEL_BOOTCMD:apalis-imx8 = "${KERNEL_BOOTCMD_OPTEE}"
 
 # DTB_PREFIX is an internal recipe variable used to append a value
 # to the FIT image configuration node that will be used to boot.
@@ -17,3 +19,5 @@ KERNEL_BOOTCMD:mx7-generic-bsp = "${KERNEL_BOOTCMD_OPTEE}"
 DTB_PREFIX_OPTEE = "optee_"
 DTB_PREFIX:prepend:mx6-generic-bsp = "${DTB_PREFIX_OPTEE}"
 DTB_PREFIX:prepend:mx7-generic-bsp = "${DTB_PREFIX_OPTEE}"
+DTB_PREFIX:prepend:colibri-imx8x = "${DTB_PREFIX_OPTEE}"
+DTB_PREFIX:prepend:apalis-imx8 = "${DTB_PREFIX_OPTEE}"

--- a/recipes-security/optee/include/optee-tdx-apalis-imx8.inc
+++ b/recipes-security/optee/include/optee-tdx-apalis-imx8.inc
@@ -1,0 +1,16 @@
+# compatible machine in OP-TEE source code
+OPTEEMACHINE = "imx-mx8qmmek"
+
+# required by NXP OP-TEE recipe
+PLATFORM_FLAVOR = "mx8qmmek"
+
+# uart base address (to print debug messages)
+UART_BASE_ADDR = "0x5a070000"
+
+# extra arguments to build OP-TEE OS
+OPTEE_OS_EXTRA_MACHINE_ARGS = "\
+    CFG_TZDRAM_START=${TDX_OPTEE_ADDR_LOAD} \
+    CFG_TZDRAM_SIZE=${TDX_OPTEE_ADDR_SIZE} \
+    CFG_NS_ENTRY_ADDR=0x95400000 \
+    CFG_DT=n \
+"

--- a/recipes-security/optee/include/optee-tdx-colibri-imx8x.inc
+++ b/recipes-security/optee/include/optee-tdx-colibri-imx8x.inc
@@ -1,0 +1,16 @@
+# compatible machine in OP-TEE source code
+OPTEEMACHINE = "imx-mx8qxpmek"
+
+# required by NXP OP-TEE recipe
+PLATFORM_FLAVOR = "mx8qxpmek"
+
+# uart base address (to print debug messages)
+UART_BASE_ADDR = "0x5a090000"
+
+# extra arguments to build OP-TEE OS
+OPTEE_OS_EXTRA_MACHINE_ARGS = "\
+    CFG_TZDRAM_START=${TDX_OPTEE_ADDR_LOAD} \
+    CFG_TZDRAM_SIZE=${TDX_OPTEE_ADDR_SIZE} \
+    CFG_NS_ENTRY_ADDR=0x95c00000 \
+    CFG_DT=n \
+"

--- a/recipes-security/optee/optee-tdx.inc
+++ b/recipes-security/optee/optee-tdx.inc
@@ -29,4 +29,24 @@ EXTRA_OEMAKE:append:pn-optee-os = "\
     ${OPTEE_OS_EXTRA_MACHINE_ARGS} \
 "
 
+generate_optee_uimage() {
+    oe_runmake uTee
+}
+do_compile:append:pn-optee-os:colibri-imx8x() {
+    generate_optee_uimage
+}
+do_compile:append:pn-optee-os:apalis-imx8() {
+    generate_optee_uimage
+}
+
+copy_optee_uimage() {
+    cp ${B}/core/uTee ${DEPLOYDIR}/uTee-${OPTEE_BIN_EXT}
+}
+do_deploy:append:pn-optee-os:colibri-imx8x() {
+    copy_optee_uimage
+}
+do_deploy:append:pn-optee-os:apalis-imx8() {
+    copy_optee_uimage
+}
+
 require ${@oe.utils.conditional('TDX_OPTEE_FS_RPMB', '1', 'optee-fs-rpmb.inc', '', d)}


### PR DESCRIPTION
Currently, the system does not boot successfully. The console output shows that OP-TEE is getting stuck early in the boot process:

```
## Booting kernel from Legacy Image at b0000000 ...                                                                                                                                                                
   Image Name:                                                                                                                                                                                                     
   Image Type:   ARM Linux Kernel Image (uncompressed)                                                                                                                                                             
   Data Size:    820992 Bytes = 801.8 KiB                                                                                                                                                                          
   Load Address: b0000000                                                                                                                                                                                          
   Entry Point:  b0000000                                                                                                                                                                                          
   Verifying Checksum ... OK                                                                                                                                                                                       
## Flattened Device Tree blob at 9d400000                                                                                                                                                                          
   Booting using the fdt blob at 0x9d400000                                                                                                                                                                        
Working FDT set to 9d400000                                                                                                                                                                                        
   Loading Kernel Image to b0000000                                                                                                                                                                                
   Loading Device Tree to 00000000fd627000, end 00000000fd675fff ... OK                                                                                                                                            
Working FDT set to fd627000                                                                                                                                                                                        
/bus@5a000000/dma-controller@5a1f0000, 58304                                                                                                                                                                       
/bus@5a000000/dma-controller@5a9f0000, 59536                                                                                                                                                                       
/bus@59000000/dma-controller@591f0000, 23860                                                                                                                                                                       
/bus@59000000/dma-controller@591f0000, 23860                                                                                                                                                                       
/bus@59000000/dma-controller@599f0000, 25212                                                                                                                                                                       
                                                                                                                                                                                                                   
Starting kernel ...                                                                                                                                                                                                
                                                                                                                                                                                                                   
D/TC:0   plat_get_aslr_seed:112 Warning: no ASLR seed                                                                                                                                                              
D/TC:0   add_phys_mem:666 VCORE_UNPG_RX_PA type TEE_RAM_RX 0xb0000000 size 0x000c4000                                                                                                                              
D/TC:0   add_phys_mem:666 VCORE_UNPG_RW_PA type TEE_RAM_RW 0xb00c4000 size 0x0013c000                                                                                                                              
D/TC:0   add_phys_mem:666 ta_base type TA_RAM 0xb0200000 size 0x01e00000                                                                                                                                           
D/TC:0   add_phys_mem:666 GICD_BASE type IO_SEC 0x51a00000 size 0x00200000                                                                                                                                         
D/TC:0   add_phys_mem:666 CONSOLE_UART_BASE type IO_NSEC 0x5a000000 size 0x00400000                                                                                                                                
D/TC:0   add_phys_mem:666 SC_IPC_BASE_SECURE type IO_SEC 0x5d1b0000 size 0x00010000                                                                                                                                
D/TC:0   add_phys_mem:666 TEE_SHMEM_START type NSEC_SHM 0xb2000000 size 0x00200000
D/TC:0   add_va_space:706 type RES_VASPACE size 0x00a00000
D/TC:0   add_va_space:706 type SHM_VASPACE size 0x02000000
D/TC:0   dump_mmap_table:838 type NSEC_SHM     va 0xaa800000..0xaa9fffff pa 0xb2000000..0xb21fffff size 0x00200000 (pgdir)
D/TC:0   dump_mmap_table:838 type TA_RAM       va 0xaaa00000..0xac7fffff pa 0xb0200000..0xb1ffffff size 0x01e00000 (pgdir)
D/TC:0   dump_mmap_table:838 type IO_NSEC      va 0xaca00000..0xacdfffff pa 0x5a000000..0x5a3fffff size 0x00400000 (pgdir)
D/TC:0   dump_mmap_table:838 type IO_SEC       va 0xace00000..0xacffffff pa 0x51a00000..0x51bfffff size 0x00200000 (pgdir)
D/TC:0   dump_mmap_table:838 type RES_VASPACE  va 0xad000000..0xad9fffff pa 0x00000000..0x009fffff size 0x00a00000 (pgdir)
D/TC:0   dump_mmap_table:838 type SHM_VASPACE  va 0xadc00000..0xafbfffff pa 0x00000000..0x01ffffff size 0x02000000 (pgdir)
D/TC:0   dump_mmap_table:838 type IO_SEC       va 0xafff0000..0xafffffff pa 0x5d1b0000..0x5d1bffff size 0x00010000 (smallpg)
D/TC:0   dump_mmap_table:838 type TEE_RAM_RX   va 0xb0000000..0xb00c3fff pa 0xb0000000..0xb00c3fff size 0x000c4000 (smallpg)
D/TC:0   dump_mmap_table:838 type TEE_RAM_RW   va 0xb00c4000..0xb01fffff pa 0xb00c4000..0xb01fffff size 0x0013c000 (smallpg)
D/TC:0   core_mmu_xlat_table_alloc:555 xlat tables used 1 / 8
D/TC:0   core_mmu_xlat_table_alloc:555 xlat tables used 2 / 8
D/TC:0   core_mmu_xlat_table_alloc:555 xlat tables used 3 / 8
```

The issue appears to be that we are attempting to boot OP-TEE directly from U-Boot while U-Boot is running in the Normal World. The correct boot flow for this platform would be to start OP-TEE from the ARM Trusted Firmware (ATF), which runs in Secure World and hands over to OP-TEE before entering the normal-world bootloader or OS.