### PR TITLE
Properly detect open/closed state of the i.MX95 devices

### DIFF
--- a/classes/include/signed/tdx-signed-harden.inc
+++ b/classes/include/signed/tdx-signed-harden.inc
@@ -50,6 +50,7 @@ TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mp ?= "ro rootwait console=tty1 console
 TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx8x ?= "ro rootwait console=tty1 console=ttyLP3,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-am62 ?= "ro rootwait console=tty1 console=ttyS2,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:aquila-am69 ?= "ro rootwait console=tty1 console=ttyS2,115200"
+TDX_SECBOOT_REQUIRED_BOOTARGS:toradex-smarc-imx95 ?= "ro rootwait console=tty1 console=ttyLP1,115200"
 
 # Name of the overlay file (without extension) that will contain the fixed part
 # of the kernel command line; this will be stored inside the FIT image; notice

--- a/recipes-bsp/u-boot/files/0001-toradex-add-helper-to-detect-closed-iMX95-downstream.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-add-helper-to-detect-closed-iMX95-downstream.patch
@@ -1,0 +1,60 @@
+From 7d915ad9914da448a3e02bc93ffd7cc258c5e25d Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Mon, 18 Aug 2025 17:38:56 -0300
+Subject: [PATCH] toradex: add helper to detect closed iMX95 (downstream)
+
+---
+ arch/arm/mach-imx/ele_ahab.c | 37 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+
+diff --git a/arch/arm/mach-imx/ele_ahab.c b/arch/arm/mach-imx/ele_ahab.c
+index cdf73ba3041..acefc62b526 100644
+--- a/arch/arm/mach-imx/ele_ahab.c
++++ b/arch/arm/mach-imx/ele_ahab.c
+@@ -460,6 +460,43 @@ static void display_life_cycle(u32 lc)
+ 		break;
+ 	}
+ }
++
++int tdx_secboot_ele_ahab_dev_is_closed(void)
++{
++	u32 lc;
++	/* Read life cycle status (as done by ele_hab.c) */
++	lc = readl(FSB_BASE_ADDR + FSB_LC_OFFSET);
++	lc &= 0x3ff;
++	switch (lc) {
++	case 0x1:	/* Blank */
++	case 0x2:	/* FAB Default */
++	case 0x4:	/* FAB */
++	case 0x8:	/* NXP Provisioned */
++		debug("Device is in a pre OEM-open state! (lc=0x%x)\n", lc);
++		return 0;
++	case 0x10:	/* OEM Open */
++		debug("Device is in OEM-open state!\n");
++		return 0;
++	case 0x20:	/* OEM secure world closed */
++	case 0x40:	/* OEM closed */
++		debug("Device is in closed state! (lc=0x%x)\n", lc);
++		return 1;
++	case 0x80:	/* OEM locked */
++		/* Undocumented state: in doubt we take it as closed. */
++		debug("Device is OEM Locked state! (lc=0x%x)\n", lc);
++		return 1;
++	case 0x100:	/* Field Return OEM */
++	case 0x200:	/* Field Return NXP */
++	case 0x400:	/* Bricked */
++		debug("Device is in some 'return' state!\n");
++		/* Note: no software runs in return states. */
++		return 0;
++	default:
++		/* Unknown state: in doubt we take it as closed. */
++		debug("Device is in an unknown state! (lc=0x%x)\n", lc);
++		return 1;
++	}
++}
+ #else
+ #define FSB_LC_OFFSET 0x41c
+ #define LC_OEM_OPEN 0x8
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/0001-toradex-common-add-shared-secboot-module.patch
+++ b/recipes-bsp/u-boot/files/0001-toradex-common-add-shared-secboot-module.patch
@@ -1,4 +1,4 @@
-From 459cde31af57c7ac5b8d52bf5cf2170e1858290b Mon Sep 17 00:00:00 2001
+From c08d0bef713ed74cf105d923ffad45cecc864094 Mon Sep 17 00:00:00 2001
 From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Date: Thu, 27 Feb 2025 23:40:32 -0300
 Subject: [PATCH] toradex: common: add shared secboot module
@@ -20,18 +20,18 @@ Upstream-Status: Inappropriate [Torizon OS specific]
 
 Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 ---
- common/tdx-secboot.c  | 298 ++++++++++++++++++++++++++++++++++++++++++
+ common/tdx-secboot.c  | 310 ++++++++++++++++++++++++++++++++++++++++++
  include/tdx-secboot.h |  21 +++
- 2 files changed, 319 insertions(+)
+ 2 files changed, 331 insertions(+)
  create mode 100644 common/tdx-secboot.c
  create mode 100644 include/tdx-secboot.h
 
 diff --git a/common/tdx-secboot.c b/common/tdx-secboot.c
 new file mode 100644
-index 00000000000..ee2dfdd884e
+index 00000000000..28d517a5b51
 --- /dev/null
 +++ b/common/tdx-secboot.c
-@@ -0,0 +1,298 @@
+@@ -0,0 +1,310 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright 2024 Toradex
@@ -49,7 +49,7 @@ index 00000000000..ee2dfdd884e
 +
 +#if defined(CONFIG_IMX_HAB)
 +#include <asm/mach-imx/hab.h>
-+#elif defined(CONFIG_AHAB_BOOT)
++#elif defined(CONFIG_AHAB_BOOT) && defined(CONFIG_ARCH_IMX8)
 +#include <firmware/imx/sci/sci.h>
 +#endif
 +
@@ -85,6 +85,8 @@ index 00000000000..ee2dfdd884e
 +		return 0;
 +	}
 +#elif defined(CONFIG_AHAB_BOOT)
++
++#if defined(CONFIG_ARCH_IMX8)
 +	u16 lc;
 +	if (sc_seco_chip_info(-1, &lc, NULL, NULL, NULL)) {
 +		/* Some error occurred. */
@@ -108,8 +110,18 @@ index 00000000000..ee2dfdd884e
 +		debug("Device is in some 'return' state!\n");
 +		return 1;
 +	default:	/* Unknown */
-+		break;
++		debug("Device is in an unknown state!\n");
++		return 0;
 +	}
++#elif defined(CONFIG_ARCH_IMX9)
++	int tdx_secboot_ele_ahab_dev_is_closed(void);
++	if (tdx_secboot_ele_ahab_dev_is_closed()) {
++		return 0;
++	}
++#else
++#error Do not know how to determine the device state (AHAB)
++#endif
++
 +#elif defined(CONFIG_ARCH_K3)
 +	int tdx_secboot_k3_dev_is_closed(void);
 +	if (tdx_secboot_k3_dev_is_closed()) {

--- a/recipes-bsp/u-boot/u-boot-secure-boot.inc
+++ b/recipes-bsp/u-boot/u-boot-secure-boot.inc
@@ -13,6 +13,7 @@ TDX_UBOOT_SECBOOT_PATCHES_UPSTREAM = " \
 # NOTE: NXP downstream does not need patch "lmb: prevent alloc overlap with reserved regions"
 TDX_UBOOT_SECBOOT_PATCHES_DOWNSTREAM = " \
     ${TDX_UBOOT_SECBOOT_PATCHES_COMMON} \
+    file://0001-toradex-add-helper-to-detect-closed-iMX95-downstream.patch \
     file://0001-toradex-integrate-shared-secboot-module-downstream.patch \
 "
 


### PR DESCRIPTION
- Add support for detecting the current life-cycle state of an i.MX95 device (impacting all hardening features).
- Set expected bootargs for the toradex-smarc-imx95.

Related-to: TOR-3932

Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
