### PR TITLE
Fix dependency issue when dm-verity is enabled 

### DIFF
--- a/classes/include/signed/tdx-signed-dmverity-tezi.inc
+++ b/classes/include/signed/tdx-signed-dmverity-tezi.inc
@@ -3,3 +3,6 @@ DEPENDS:remove:pn-${DM_VERITY_IMAGE} = "imx-boot"
 IMAGE_BOOTFS_DEPENDS:pn-${DM_VERITY_IMAGE} = "virtual/kernel:do_build"
 IMAGE_BOOTFS_DEPENDS:mx8-generic-bsp:pn-${DM_VERITY_IMAGE} = "${@ 'imx-boot:do_build' if d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' else 'virtual/kernel:do_build'}"
 do_image_bootfs[depends] += "${IMAGE_BOOTFS_DEPENDS}"
+
+# make sure the kernel FIT image with the ramdisk is deployed before generating the Tezi image
+do_image_bootfs[depends] += "virtual/kernel:do_deploy"


### PR DESCRIPTION
Fix the following build error:

```
08-21:18:57:05  ERROR: tdx-reference-minimal-image-1.0-r0 do_image_bootfs: Command 'install -m 0644 -D /workdir/oe/tmp-glibc/deploy/images/apalis-imx8/fitImage /workdir/oe/tmp/work/apalis_imx8-tdx-linux/tdx-reference-minimal-image/1.0/bootfs/fitImage' returned 1:
08-21:18:57:05  b"install: cannot stat '/workdir/oe/tmp-glibc/deploy/images/apalis-imx8/fitImage': No such file or directory\n"
```

This was only reproducible in CI, and only on Apalis iMX8 and Colibri iMX8X. It seems there is some weird dependency issue when building a Tezi image with `dm-verity` enabled for those machines. The `do_image_bootfs` task from the Tezi class runs before `do_deploy` from the kernel recipe, so the `fitImage` is not yet available.

Fix it by setting the correct dependency:

```
tdx-reference-minimal-image:do_image_bootfs -> virtual/kernel:do_deploy
```