### PR TITLE
optee-client: fix build failure with NXP downstream recipe

### DIFF
--- a/recipes-security/optee/optee-client_%.bbappend
+++ b/recipes-security/optee/optee-client_%.bbappend
@@ -4,6 +4,12 @@ SRC_URI += "\
     file://tee-supplicant.rules \
 "
 
+# UNPACKDIR is a new variable introduced in Styhead, but optee-client recipe
+# from meta-freescale is already using it, and this is breaking the build, so
+# so lets make sure it points to WORKDIR. This can probably be removed as soon
+# as we move to Styhead or later version.
+UNPACKDIR = "${WORKDIR}"
+
 # The optee-client upstream recipe installs a tee-supplicant template unit
 # that requires an udev rule to start the tee supplicant daemon automatically
 do_install:append() {


### PR DESCRIPTION
Fixes the following error during do_install:

09-05:18:57:01  | install: cannot stat '/tee-supplicant@.service': No such file or directory
09-05:18:54:26  NOTE: recipe optee-client-4.4.0.imx-r0: task do_install: Failed

The issue occurs because the downstream optee-client recipe from meta-freescale uses the UNPACKDIR variable, which was only introduced in Styhead.

Fix it by initializing UNPACKDIR with WORKDIR.