### PR TITLE
Enable all security features for Verdin AM62P

### DIFF
--- a/classes/include/signed/machine/verdin-am62p.inc
+++ b/classes/include/signed/machine/verdin-am62p.inc
@@ -1,0 +1,2 @@
+# use tiboot3.bin secure boot variant in Tezi
+FIRMWARE_BINARY[0099] := "tiboot3-am62px-${SYSFW_SUFFIX}-verdin.bin"

--- a/classes/include/signed/tdx-signed-harden.inc
+++ b/classes/include/signed/tdx-signed-harden.inc
@@ -49,6 +49,7 @@ TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mm ?= "ro rootwait console=tty1 console
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-imx8mp ?= "ro rootwait console=tty1 console=ttymxc2,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx8x ?= "ro rootwait console=tty1 console=ttyLP3,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-am62 ?= "ro rootwait console=tty1 console=ttyS2,115200"
+TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-am62p ?= "ro rootwait console=tty1 console=ttyS2,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:aquila-am69 ?= "ro rootwait console=tty1 console=ttyS2,115200"
 TDX_SECBOOT_REQUIRED_BOOTARGS:toradex-smarc-imx95 ?= "ro rootwait console=tty1 console=ttyLP1,115200"
 

--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -81,6 +81,7 @@ python validate_optee_support() {
         'colibri-imx7-emmc',
         'imx95-19x19-verdin',
         'verdin-am62',
+        'verdin-am62p',
         'verdin-imx8mm',
         'verdin-imx8mp',
     ]

--- a/docs/README-encryption.md
+++ b/docs/README-encryption.md
@@ -11,7 +11,8 @@ Encryption is currently supported on the following SoMs:
 - Colibri iMX7D (1GB eMMC variant only)
 - Colibri iMX8X
 - iMX95 Verdin EVK
-- Verdin AM62 (requires the availability of a TPM)
+- Verdin AM62
+- Verdin AM62P
 - Verdin iMX8MM
 - Verdin iMX8MP
 

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -14,6 +14,7 @@ This layer provides support for running OP-TEE on the following SoMs:
 - Colibri iMX7D (1GB eMMC variant only)
 - iMX95 Verdin EVK
 - Verdin AM62
+- Verdin AM62P
 - Verdin iMX8MP
 - Verdin iMX8MM
 

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -12,6 +12,7 @@ Secure boot is currently supported on the following SoMs:
 - Colibri iMX7D (1GB eMMC variant only)
 - Colibri iMX8X
 - Verdin AM62
+- Verdin AM62P
 - Verdin iMX8MM
 - Verdin iMX8MP
 - iMX95 Verdin EVK

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
@@ -75,3 +75,10 @@ do_install() {
         install -m 0644 ${WORKDIR}/99-tpm.rules ${D}${sysconfdir}/udev/rules.d/99-tpm.rules
     fi
 }
+
+# HW offload is not working properly on Verdin AM62P when trying to mount a partition
+# with dm-crypt, so let's disable it as a workaround for now.
+do_install:append:verdin-am62p() {
+    install -d ${D}${sysconfdir}/modprobe.d/
+    echo "blacklist sa2ul" > ${D}${sysconfdir}/modprobe.d/sa2ul.conf
+}

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
@@ -57,8 +57,8 @@ do_install() {
         dep_req="Requires=dev-tpm0.device"
         dep_all="${dep_bef}\n${dep_aft}\n${dep_req}"
     elif [ ${TDX_ENC_KEY_BACKEND} = "tee" ]; then
-        dep_aft="After=tee-supplicant.service"
-        dep_req="Requires=tee-supplicant.service"
+        dep_aft="After=tee-supplicant@teepriv0.service"
+        dep_req="Requires=tee-supplicant@teepriv0.service"
         dep_all="${dep_aft}\n${dep_req}"
     else
         dep_bef="Before=local-fs.target"

--- a/recipes-security/optee/include/optee-tdx-verdin-am62p.inc
+++ b/recipes-security/optee/include/optee-tdx-verdin-am62p.inc
@@ -1,0 +1,2 @@
+# eMMC RPMB partition device node ID
+TDX_OPTEE_FS_RPMB_DEV_ID ?= "0"


### PR DESCRIPTION
This PR is enabling all security features for Verdin AM62P (Secure Boot, OP-TEE, Encryption).

Build and runtime tested on Verdin AM62P with Verdin Development Board.