### PR TITLE
Add support for SMARC iMX95

### DIFF
--- a/classes/include/signed/tdx-signed-dmverity-tezi.inc
+++ b/classes/include/signed/tdx-signed-dmverity-tezi.inc
@@ -2,6 +2,7 @@ IMAGE_FSTYPES:remove = "wic.bmap wic.gz"
 DEPENDS:remove:pn-${DM_VERITY_IMAGE} = "imx-boot"
 IMAGE_BOOTFS_DEPENDS:pn-${DM_VERITY_IMAGE} = "virtual/kernel:do_build"
 IMAGE_BOOTFS_DEPENDS:mx8-generic-bsp:pn-${DM_VERITY_IMAGE} = "${@ 'imx-boot:do_build' if d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' else 'virtual/kernel:do_build'}"
+IMAGE_BOOTFS_DEPENDS:mx9-generic-bsp:pn-${DM_VERITY_IMAGE} = "${@ 'imx-boot:do_build' if d.getVar('UBOOT_PROVIDES_BOOT_CONTAINER') == '0' else 'virtual/kernel:do_build'}"
 do_image_bootfs[depends] += "${IMAGE_BOOTFS_DEPENDS}"
 
 # make sure the kernel FIT image with the ramdisk is deployed before generating the Tezi image

--- a/classes/tdx-encrypted.bbclass
+++ b/classes/tdx-encrypted.bbclass
@@ -5,11 +5,13 @@ DISTROOVERRIDES .= ":tdx-encrypted"
 # This variable defines how the encryption key is managed
 # Available options:
 #    cleartext -> key is stored in clear text (for testing purposes only!)
-#    caam      -> use CAAM (available only on iMX based SoMs)
+#    caam      -> use CAAM (available only on iMX6/7/8 based SoMs)
 #    tpm       -> use TPM (Trusted Platform Module)
 #    tee       -> use TEE (Trusted Execution Environment)
 TDX_ENC_KEY_BACKEND ?= ""
-TDX_ENC_KEY_BACKEND:imx-generic-bsp ?= "caam"
+TDX_ENC_KEY_BACKEND:mx6-generic-bsp ?= "caam"
+TDX_ENC_KEY_BACKEND:mx7-generic-bsp ?= "caam"
+TDX_ENC_KEY_BACKEND:mx8-generic-bsp ?= "caam"
 
 # Encryption key blob location
 # This variable defines where the encrypted key will be stored

--- a/classes/tdx-optee.bbclass
+++ b/classes/tdx-optee.bbclass
@@ -81,6 +81,7 @@ python validate_optee_support() {
         'colibri-imx7-emmc',
         'imx95-19x19-verdin',
         'toradex-smarc-imx8mp',
+        'toradex-smarc-imx95',
         'verdin-am62',
         'verdin-am62p',
         'verdin-imx8mm',

--- a/docs/README-encryption.md
+++ b/docs/README-encryption.md
@@ -12,6 +12,7 @@ Encryption is currently supported on the following SoMs:
 - Colibri iMX8X
 - iMX95 Verdin EVK
 - SMARC iMX8MP
+- SMARC iMX95
 - Verdin AM62
 - Verdin AM62P
 - Verdin iMX8MM
@@ -70,7 +71,7 @@ A few additional variables are available to customize the behavior of the data-a
 
 | Variable | Description | Default value |
 | :------- | :---------- | :------------ |
-| `TDX_ENC_KEY_BACKEND` | Backend used to manage the encryption key. Allowed values: `caam`, `tpm`, `tee` or `cleartext`. If configured with `caam`, it will use Trusted Keys backed by the CAAM device (available on NXP iMX-based SoMs). If configured with `tpm`, it will use Trusted Keys backed by a TPM device (availability depends on the hardware). If configured with `tee`, it will use Trusted Keys backed by a Trusted Execution Environment. If configured with `cleartext`, the encryption key will be stored in clear text in the file system (use `cleartext` only for testing purposes!) | `caam` on iMX based SoMs, empty otherwise |
+| `TDX_ENC_KEY_BACKEND` | Backend used to manage the encryption key. Allowed values: `caam`, `tpm`, `tee` or `cleartext`. If configured with `caam`, it will use Trusted Keys backed by the CAAM device (available on NXP iMX-based SoMs). If configured with `tpm`, it will use Trusted Keys backed by a TPM device (availability depends on the hardware). If configured with `tee`, it will use Trusted Keys backed by a Trusted Execution Environment. If configured with `cleartext`, the encryption key will be stored in clear text in the file system (use `cleartext` only for testing purposes!) | `caam` on iMX6/7/8 based SoMs, empty otherwise |
 | `TDX_ENC_KEY_LOCATION` | Location to store the encryption key blob. Allowed values: `filesystem` or `partition`. If configured with `filesystem`, the encryption key blob will be stored as a file in the filesystem (location defined by the `TDX_ENC_KEY_DIR` variable. If configured with `partition`, the encryption key blob will be stored in a block of the disk outside the dm-crypt partition (useful if the rootfs filesystem is read-only) | `filesystem` |
 | `TDX_ENC_KEY_DIR` | Directory to store the encryption key blob | `/var/local/private/.keys` |
 | `TDX_ENC_KEY_FILE` | File name of the encryption key blob | `tdx-enc-key.blob` |

--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -14,6 +14,7 @@ This layer provides support for running OP-TEE on the following SoMs:
 - Colibri iMX7D (1GB eMMC variant only)
 - iMX95 Verdin EVK
 - SMARC iMX8MP
+- SMARC iMX95
 - Verdin AM62
 - Verdin AM62P
 - Verdin iMX8MP

--- a/docs/README-secure-boot.md
+++ b/docs/README-secure-boot.md
@@ -13,6 +13,7 @@ Secure boot is currently supported on the following SoMs:
 - Colibri iMX8X
 - iMX95 Verdin EVK
 - SMARC iMX8MP
+- SMARC iMX95
 - Verdin AM62
 - Verdin AM62P
 - Verdin iMX8MM

--- a/recipes-security/optee/include/optee-tdx-toradex-smarc-imx95.inc
+++ b/recipes-security/optee/include/optee-tdx-toradex-smarc-imx95.inc
@@ -1,0 +1,5 @@
+# uart base address (to print debug messages)
+UART_BASE_ADDR = "0x44380000"
+
+# eMMC RPMB partition device node ID
+TDX_OPTEE_FS_RPMB_DEV_ID ?= "0"


### PR DESCRIPTION
This PR implements the missing changes required to support all security features on SMARC iMX95.

Build and runtime tested on the SMARC Development Board.