### PR TITLE
Document fusing issue on early i.MX95 silicon revisions

### DIFF
--- a/docs/README-secure-boot-imx.md
+++ b/docs/README-secure-boot-imx.md
@@ -41,6 +41,7 @@ The complete list of variables can be found in the `imx-hab.bbclass` file.
 
 - Starting from version 4.0.0, the NXP CST tool may not work as expected on older Linux distributions (e.g., Ubuntu 20.04). If you are using NXP CST 4.0.0 or later, it is recommended to use a more recent Linux distribution (e.g., Ubuntu 24.04) to ensure compatibility and avoid potential issues.
 - As of April 2025, SGK is not supported in the current firmware for SoCs using the EdgeLock Secure Enclave (ELE), which includes iMX8ULP and iMX9x. Consequently, when building for machines based on these SoCs, the use of subordinate signing keys (SGK) will be disabled, and the boot container will be signed directly with the Super Root Keys (SRK).
+- On i.MX95 silicon revisions A0 and A1, the fuse command in U-Boot does not work with the latest Toradex BSP. If you are using one of these early silicon revisions and encounter issues when programming fuses, try using an older Toradex Easy Installer release (prior to August). If the problem persists, please open an issue in this repository or contact the Toradex support team for assistance.
 
 ### Closing the device
 


### PR DESCRIPTION
The fuse command in U-Boot from the latest Toradex BSP does not work properly on early i.MX95 silicon revisions (A0/A1).

Add a note to the documentation describing the issue and a recommended workaround.