### PR TITLE
Fixes related to the encryption feature

### DIFF
--- a/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler_1.0.bb
@@ -76,9 +76,9 @@ do_install() {
     fi
 }
 
-# HW offload is not working properly on Verdin AM62P when trying to mount a partition
+# HW offload is not working properly on K3 platforms when trying to mount a partition
 # with dm-crypt, so let's disable it as a workaround for now.
-do_install:append:verdin-am62p() {
+do_install:append:k3() {
     install -d ${D}${sysconfdir}/modprobe.d/
     echo "blacklist sa2ul" > ${D}${sysconfdir}/modprobe.d/sa2ul.conf
 }

--- a/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/recipes-core/udev/udev-extraconf_%.bbappend
@@ -1,0 +1,3 @@
+do_install:append:tdx-encrypted() {
+    echo ${TDX_ENC_STORAGE_LOCATION} >> ${D}${sysconfdir}/udev/mount.ignorelist
+}


### PR DESCRIPTION
This PR has some fixes related to the encryption feature.

* Avoid `systemd-mount` from automounting the data partition, which was preventing the `tdx-enc` script from preparing the encrypted partition at the first boot.
* Disable HW crypto offload on all K3 platforms, which is causing issues when using dm-crypt.

Build and runtime tested on Aquila AM69, and Verdin AM62(P)

Closes #97 