### PR TITLE
Add encrypted partition to usermount's ignore list

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -34,4 +34,5 @@ BBFILES_DYNAMIC += " \
     toradex-ti-layer:${LAYERDIR}/dynamic-layers/toradex-ti/*/*/*.bbappend \
     toradex-nxp-layer:${LAYERDIR}/dynamic-layers/toradex-nxp/*/*/*.bbappend \
     toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/toradex-bsp-common/*/*/*.bbappend \
+    meta-toradex-torizon:${LAYERDIR}/dynamic-layers/meta-toradex-torizon/*/*/*.bbappend \
 "

--- a/dynamic-layers/meta-toradex-torizon/recipes-support/usermount/usermount_%.bbappend
+++ b/dynamic-layers/meta-toradex-torizon/recipes-support/usermount/usermount_%.bbappend
@@ -1,0 +1,4 @@
+do_install:append:tdx-encrypted() {
+    install -d ${D}${sysconfdir}/usermount
+    echo ${TDX_ENC_STORAGE_LOCATION} >> ${D}${sysconfdir}/usermount/ignorelist
+}


### PR DESCRIPTION
Prevents usermount (via /usr/bin/usermount-mounter) from Torizon OS to try to automount the encrypted partition at boot time.

Build and runtime tested on Verdin iMX8MP