### PR TITLE
Set signing class name

### DIFF
--- a/classes/tdx-signed.bbclass
+++ b/classes/tdx-signed.bbclass
@@ -12,8 +12,12 @@ require ${@ 'include/signed/tdx-signed-imx-hab.inc' if 'imx-generic-bsp' in d.ge
 require ${@ 'include/signed/tdx-signed-k3-secboot.inc' if 'k3r5' in d.getVar('OVERRIDES').split(':') else ''}
 require ${@ 'include/signed/tdx-signed-k3-secboot.inc' if 'k3' in d.getVar('OVERRIDES').split(':') else ''}
 
-# Hardening configuration
+# hardening configuration
 require include/signed/tdx-signed-harden.inc
 
 # machine-specific fixups for the signed image
 include include/signed/machine/${MACHINE}.inc
+
+# signing class name (informational, may be displayed to users);
+# derived classes should override this
+TDX_SIGNING_CLASS = "tdx-signed"

--- a/classes/tdxref-signed.bbclass
+++ b/classes/tdxref-signed.bbclass
@@ -3,3 +3,6 @@ inherit tdx-signed
 
 # boot a signed rootfs via dm-verity
 inherit tdx-signed-dmverity
+
+# override signing class name (informational, may be displayed to users)
+TDX_SIGNING_CLASS = "tdxref-signed"


### PR DESCRIPTION
Set variable `TDX_SIGNING_CLASS` to the name of the signing class. The idea is to make that information available to other layers so they can add it to the OS image name/description (as that present in the Toradex Easy Installer `image.json` file); this would allow users to tell signed/non-signed images apart.
