### PR TITLE
tdx-tezi-data-partition: support configurable data partition size and maximization

### DIFF
--- a/classes/tdx-tezi-data-partition.bbclass
+++ b/classes/tdx-tezi-data-partition.bbclass
@@ -28,10 +28,17 @@ TDX_TEZI_DATA_PARTITION_MOUNTPOINT ?= "/data"
 # data partition mount flags
 TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS ?= "rw,nosuid,nodev,noatime,errors=remount-ro"
 
+# data partition want_maximized setting
+# "0": do not maximize partition
+# "1": maximize partition size if multiple partitions share this setting
+#      distributing remaining space evenly
+TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED ?= "1"
+
 # image_type_tezi.bbclass configuration
 TEZI_DATA_ENABLED = "1"
 TEZI_DATA_FSTYPE = "${TDX_TEZI_DATA_PARTITION_TYPE}"
 TEZI_DATA_LABEL = "${TDX_TEZI_DATA_PARTITION_LABEL}"
+TEZI_DATA_WANT_MAXIMIZED = "${TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED}"
 
 # check if tezi image is enabled
 addhandler validate_tezi_support

--- a/classes/tdx-tezi-data-partition.bbclass
+++ b/classes/tdx-tezi-data-partition.bbclass
@@ -28,6 +28,9 @@ TDX_TEZI_DATA_PARTITION_MOUNTPOINT ?= "/data"
 # data partition mount flags
 TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS ?= "rw,nosuid,nodev,noatime,errors=remount-ro"
 
+# data partition nominal size in MB
+TDX_TEZI_DATA_PARTITION_SIZE_NOMINAL ?= "512"
+
 # data partition want_maximized setting
 # "0": do not maximize partition
 # "1": maximize partition size if multiple partitions share this setting
@@ -38,6 +41,7 @@ TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED ?= "1"
 TEZI_DATA_ENABLED = "1"
 TEZI_DATA_FSTYPE = "${TDX_TEZI_DATA_PARTITION_TYPE}"
 TEZI_DATA_LABEL = "${TDX_TEZI_DATA_PARTITION_LABEL}"
+TEZI_DATA_PART_SIZE = "${TDX_TEZI_DATA_PARTITION_SIZE_NOMINAL}"
 TEZI_DATA_WANT_MAXIMIZED = "${TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED}"
 
 # check if tezi image is enabled

--- a/docs/README-data-partition.md
+++ b/docs/README-data-partition.md
@@ -23,6 +23,8 @@ Additional variables can be used to customize the behavior of this feature:
 | :------- | :---------- | :------------ |
 | `TDX_TEZI_DATA_PARTITION_TYPE` | Data partition filesystem type. Supported values are `ext2`, `ext3`, `ext4`, `fat` and `ubifs`. The supported values are limited to what Toradex Easy Installer supports | `ext4` |
 | `TDX_TEZI_DATA_PARTITION_LABEL` | Label that will be used to format and mount the data partition | `DATA` |
+| `TDX_TEZI_DATA_PARTITION_SIZE_NOMINAL` | Nominal size of the data partition in MB. This is the actual partition size when `TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED` is set to `0`, or the minimum size when set to `1` | `512` |
+| `TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED` | Set to `1` to maximize partition size if multiple partitions share this setting distributing remaining space evenly, or `0` to use only the nominal size specified by `TDX_TEZI_DATA_PARTITION_SIZE_NOMINAL` | `1` |
 | `TDX_TEZI_DATA_PARTITION_AUTOMOUNT` | Set to `1` to automatically mount the data partition at boot time, or `0` to disable automouting the partition; when set to `-1` the partition won't even be listed in fstab (it should be mounted by other means) | `-1` if class `tdx-encrypted` is in use or `1` otherwise |
 | `TDX_TEZI_DATA_PARTITION_MOUNTPOINT` | Directory where the data partition should be mounted | `/data` |
 | `TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS` | Flags used to mount the data partition. See the `mount` man page for more information on the available mount flags | `rw,nosuid,nodev,noatime, errors=remount-ro` |


### PR DESCRIPTION
NOTE: This PR depends on https://git.toradex.com/cgit/meta-toradex-bsp-common.git/commit/?h=scarthgap-7.x.y&id=df1b539e6d9144aa20e3d25e09fc1082346aa07e

----

This PR adds two new optional user-configurable variables to the `tdx-tezi-data-partition` bbclass, providing greater flexibility when configuring data partitions in Toradex Easy Installer images.

### Changes
1. `TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED` variable
    - Allows users to control whether the data partition should be maximized to use all available space
    - Set to `"1"` (default) to maximize the partition - if multiple partitions share this setting, remaining space is distributed evenly
    - Set to `"0"` to use only the nominal size
    - Maintains backward compatibility with default value of "1"
2. `TDX_TEZI_DATA_PARTITION_SIZE_NOMINAL` variable
    - Allows users to specify the nominal size of the data partition in MB
    - When `TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED = "0"`, this is the actual partition size
    - When `TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED = "1"`, this serves as the minimum size
    - Defaults to "512" (512 MB) for backward compatibility

### Use Case
These variables are particularly useful when:
- You need a fixed-size data partition for deterministic storage allocation
- You want to reserve space for other partitions or future expansion
- You need to control partition sizes for testing or specific deployment requirements

### Example Configuration
```
INHERIT += "tdx-tezi-data-partition"
TDX_TEZI_DATA_PARTITION_SIZE_NOMINAL = "1024"      # 1GB partition
TDX_TEZI_DATA_PARTITION_WANT_MAXIMIZED = "0"       # Don't maximize
```