### PR TITLE
Add diagnostic logging to create_fuse_cmds.sh for easier troubleshooting

### DIFF
--- a/recipes-bsp/imx-fuses/files/create_fuse_cmds.sh
+++ b/recipes-bsp/imx-fuses/files/create_fuse_cmds.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[ "${XTRACE}" = "1" ] && set -x
+
 set -e
 
 # parameters
@@ -35,6 +37,8 @@ fuse_write_line() {
 create_fuse_cmds() {
     local template_file="$1"
 
+    echo "Generating fusing files using template [$template_file]."
+
     if [ ! -e "$template_file" ]; then
         echo "Template file not found [$template_file]!"
         return 1
@@ -42,6 +46,8 @@ create_fuse_cmds() {
 
     cp "$template_file" "$FUSE_INFO_FILE"
     echo "${WARNING1}" > "$FUSE_CMDS_FILE"
+
+    echo "Writing fusing commands..."
 
     for hexval in $(hexdump -e '/4 "0x"' -e '/4 "%X""\n"' "${SRK_FUSE_FILE}"); do
         fuse_info=$(grep -m 1 "^H:F:.*:$" "$FUSE_INFO_FILE")
@@ -59,6 +65,8 @@ create_fuse_cmds() {
 
     echo -e "\n${WARNING2}" >> "$FUSE_CMDS_FILE"
 
+    echo "Writing 'close' command..."
+
     if grep -q "H:T:HAB" "$FUSE_INFO_FILE"; then
         fuse_info=$(grep "^H:C:" "$FUSE_INFO_FILE")
         bank=$(echo "$fuse_info" | cut -d: -f3)
@@ -68,7 +76,12 @@ create_fuse_cmds() {
     else
         echo "ahab_close" >> "$FUSE_CMDS_FILE"
     fi
+
+    echo "Fusing files successfully generated!"
 }
+
+# Print command for Yocto logs
+echo "$0" "$@"
 
 case ${SOC} in
     "IMX6ULL"|"IMX6")


### PR DESCRIPTION
After refactoring the generation of the fusing files, the build for iMX95 based SoCs in CI started to failing at the `imx-boot:do_compile` task.

I could not reproduce the issue locally, and the logs from CI are inconclusive:

```
11-11:18:56:04  | /workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/mx8_sign.sh -t u-boot-atf-container.img
11-11:18:56:04  | Verified TDX_IMX_HAB_CST_BIN=/workdir/signing_ressources/cst-3.3.2/linux64/bin/cst
11-11:18:56:04  | Verified TDX_IMX_HAB_CST_SRK=/workdir/signing_ressources/cst-3.3.2/crts/SRK_1_2_3_4_table.bin
11-11:18:56:04  | Verified TDX_IMX_HAB_CST_SRK_CERT=/workdir/signing_ressources/cst-3.3.2/crts/SRK1_sha256_4096_65537_v3_ca_crt.pem
11-11:18:56:04  | Verified TDX_IMX_HAB_CST_SGK_CERT=/workdir/signing_ressources/cst-3.3.2/crts/SGK1_1_sha256_4096_65537_v3_usr_crt.pem
11-11:18:56:04  | Verified UNSIGNED_IMAGE=/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/u-boot-atf-container.img
11-11:18:56:04  | Verified LOG_MKIMAGE=/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/mkimage-u-boot-atf-container.img.log
11-11:18:56:04  | Creating CSF file: /workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/u-boot-atf-container.img.csf
11-11:18:56:04  | Using SRK1 for signing.
11-11:18:56:04  | Inferred that CA flag was not set; signing with SRK only.
11-11:18:56:04  | Signing '/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/u-boot-atf-container.img' with CST tool.
11-11:18:56:04  | Tool location: '/workdir/signing_ressources/cst-3.3.2/linux64/bin/cst'
11-11:18:56:04  | CSF location: '/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/u-boot-atf-container.img.csf'
11-11:18:56:04  | CSF Processed successfully and signed image available in /workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/u-boot-atf-container.img-signed
11-11:18:56:04  | '/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/u-boot-atf-container.img-signed' -> '/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/u-boot-atf-container.img'
11-11:18:56:04  | /workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/mx8_sign.sh -t flash_a55
11-11:18:56:04  | Verified TDX_IMX_HAB_CST_BIN=/workdir/signing_ressources/cst-3.3.2/linux64/bin/cst
11-11:18:56:04  | Verified TDX_IMX_HAB_CST_SRK=/workdir/signing_ressources/cst-3.3.2/crts/SRK_1_2_3_4_table.bin
11-11:18:56:04  | Verified TDX_IMX_HAB_CST_SRK_CERT=/workdir/signing_ressources/cst-3.3.2/crts/SRK1_sha256_4096_65537_v3_ca_crt.pem
11-11:18:56:04  | Verified TDX_IMX_HAB_CST_SGK_CERT=/workdir/signing_ressources/cst-3.3.2/crts/SGK1_1_sha256_4096_65537_v3_usr_crt.pem
11-11:18:56:04  | Verified UNSIGNED_IMAGE=/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/flash.bin
11-11:18:56:04  | Verified LOG_MKIMAGE=/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/mkimage-flash_a55.log
11-11:18:56:04  | Creating CSF file: /workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/flash_a55.csf
11-11:18:56:04  | Using SRK1 for signing.
11-11:18:56:04  | Inferred that CA flag was not set; signing with SRK only.
11-11:18:56:04  | Signing '/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/flash.bin' with CST tool.
11-11:18:56:04  | Tool location: '/workdir/signing_ressources/cst-3.3.2/linux64/bin/cst'
11-11:18:56:04  | CSF location: '/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/flash_a55.csf'
11-11:18:56:04  | CSF Processed successfully and signed image available in /workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/flash.bin-signed
11-11:18:56:04  | '/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/iMX95/flash.bin-signed' -> '/workdir/oe/tmp/work/verdin_imx95-tdx-linux/imx-boot/1.0/git/imx-boot-verdin-imx95-sd.bin-flash_a55'
11-11:18:56:04  | WARNING: exit code 1 from a shell command.
11-11:18:56:04  NOTE: recipe imx-boot-1.0-r0: task do_compile: Failed
11-11:18:56:04  ERROR: Task (/workdir/oe/build/../layers/meta-freescale/recipes-bsp/imx-mkimage/imx-boot_1.0.bb:do_compile) failed with exit code '1'
```

Adding some logs to `create_fuse_cmds.sh` might help debug this issue.
