### PR TITLE
Fix Colibri iMX8X automatic fusing issue

### DIFF
--- a/classes/include/signed/tdx-signed-imx-hab-tezi.inc
+++ b/classes/include/signed/tdx-signed-imx-hab-tezi.inc
@@ -4,7 +4,7 @@ TDX_IMX_HAB_GEN_UBOOT_FUSING_CMD ?= "0"
 # this is mostly intended for development/tests, so it will only program
 # the fuses but not close the device
 add_fusing_cmd_to_uboot_env() {
-    uboot_cmd="prog_secure_boot_fuses=echo Programming fuses..."
+    uboot_cmd="prog_secure_boot_fuses=echo Programming fuses...; setenv force_prog_ecc y"
     for line in $(grep "^H:F:" ${DEPLOY_DIR_IMAGE}/imx-config.fuse); do
         bank=$(echo "$line" | cut -d: -f3)
         word=$(echo "$line" | cut -d: -f4)


### PR DESCRIPTION
On some SoCs (e.g. i.MX8X), `fuse prog` prompts for an additional confirmation when targeting ECC-protected fuse words, even when -y is used:

```
Colibri iMX8X # fuse prog -y 0 730 0xBB31FAAE
Programming bank 0 word 0x000002da to 0x18c3f653... Warning: Words in this index range have ECC protection and can only be programmed once per word. Individual bit operations will be rejected after the first one.
 Really program this word? <y/N>
```

This breaks automated fusing in CI and can cause LAVA jobs to time out waiting for user input.

Fix this by setting `force_prog_ecc=y` in U-Boot before running the fusing commands. The variable is only applicable to platforms that implement this behavior (e.g. iMX8X) and it is ignored elsewhere, so setting it unconditionally is safe.