### PR TITLE
Enable HSM support on AHAB based devices

### DIFF
--- a/dynamic-layers/freescale/recipes-bsp/imx-mkimage/files/mx8_sign.sh
+++ b/dynamic-layers/freescale/recipes-bsp/imx-mkimage/files/mx8_sign.sh
@@ -31,6 +31,11 @@ help() {
     echo "                              e.g. SRK1_sha256_2048_65537_v3_usr_crt.pem (when CA flag is not set)"
     echo "    TDX_IMX_HAB_CST_SGK_CERT  Path to SGK public key certificate (needed only if CA flag is set for SRK)"
     echo "                              e.g. SGK1_1_sha256_2048_65537_v3_usr_crt.pem"
+    echo "    TDX_IMX_HAB_CST_HSM       Enable usage of HSM (via PKCS11) when set to 1"
+    echo "    TDX_IMX_HAB_CST_SRK_CA    Whether or not the SRK certificates have the CA flag"
+    echo "                              Only used when HSM is enabled (TDX_IMX_HAB_CST_HSM=1)"
+    echo "    TDX_IMX_HAB_CST_SRK_INDEX Index of the SRK to be used for signing (1..4)"
+    echo "                              Only used when HSM is enabled (TDX_IMX_HAB_CST_HSM=1)"
     echo "    TDX_IMX_HAB_CST_TEMPLATE  Name of the Command Sequence File (CSF) file"
     echo "    UNSIGNED_IMAGE            Path to unsigned image"
     echo "    LOG_MKIMAGE               Path to mkimage log file"
@@ -87,13 +92,27 @@ validate_environ() {
     fi
     check_fileref "${TDX_IMX_HAB_CST_BIN}" "TDX_IMX_HAB_CST_BIN"
     check_fileref "${TDX_IMX_HAB_CST_SRK}" "TDX_IMX_HAB_CST_SRK"
-    check_fileref "${TDX_IMX_HAB_CST_SRK_CERT}" "TDX_IMX_HAB_CST_SRK_CERT"
-    if [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
-        check_fileref "${TDX_IMX_HAB_CST_SGK_CERT}" "TDX_IMX_HAB_CST_SGK_CERT"
+
+    # Only check certificates if HSM is disabled (when HSM is used, these
+    # variables are actually PKCS11 URIs)
+    if [ "${TDX_IMX_HAB_CST_HSM}" = 0 ]; then
+        check_fileref "${TDX_IMX_HAB_CST_SRK_CERT}" "TDX_IMX_HAB_CST_SRK_CERT"
+        if [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
+            check_fileref "${TDX_IMX_HAB_CST_SGK_CERT}" "TDX_IMX_HAB_CST_SGK_CERT"
+        fi
     fi
+
     check_fileref "${TDX_IMX_HAB_CST_TEMPLATE}" "TDX_IMX_HAB_CST_TEMPLATE"
     check_fileref "${UNSIGNED_IMAGE}" "UNSIGNED_IMAGE"
     check_fileref "${LOG_MKIMAGE}" "LOG_MKIMAGE"
+
+    # Add "-b pkcs11" if HSM is enabled and it's not already present
+    if [ "${TDX_IMX_HAB_CST_HSM}" = 1 ]; then
+        case " ${TDX_IMX_HAB_CST_ARGS} " in
+            *" -b pkcs11 "*) ;;
+            *) TDX_IMX_HAB_CST_ARGS="${TDX_IMX_HAB_CST_ARGS} -b pkcs11" ;;
+        esac
+    fi
 }
 
 # Generate a CSF text file (to be used as input to the CST tool) based on a template.
@@ -104,11 +123,16 @@ generate_csf_ahab() {
     echo "Creating CSF file: ${image_csf}"
     cp "${DIR_SCRIPT}/${TDX_IMX_HAB_CST_TEMPLATE}" "${image_csf}"
 
-    # Determine key index (use file name):
+    # Determine key index
     local kidx
-    kidx=${TDX_IMX_HAB_CST_SRK_CERT##*/}
-    kidx=${kidx##SRK}
-    kidx=${kidx%%_*}
+    if [ "${TDX_IMX_HAB_CST_HSM}" = 1 ]; then
+        kidx=${TDX_IMX_HAB_CST_SRK_INDEX}
+    else
+        kidx=${TDX_IMX_HAB_CST_SRK_CERT##*/}
+        kidx=${kidx##SRK}
+        kidx=${kidx%%_*}
+    fi
+
     if [ "${#kidx}" != 1 ]; then
         echo "Certificate file name (defined by TDX_IMX_HAB_CST_SRK_CERT) does" \
              "not match expected pattern - could not determine SRK key index."
@@ -125,7 +149,9 @@ generate_csf_ahab() {
 
     # Determine whether or not the CA flag was set:
     local ca
-    if [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
+    if [ "${TDX_IMX_HAB_CST_HSM}" = 1 ]; then
+        ca=${TDX_IMX_HAB_CST_SRK_CA}
+    elif [ "${TDX_IMX_HAB_CST_SRK_CERT##*_ca_}" = "crt.pem" ]; then
         ca=1
     elif [ "${TDX_IMX_HAB_CST_SRK_CERT##*_usr_}" = "crt.pem" ]; then
         ca=0

--- a/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab-hsm.inc
+++ b/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab-hsm.inc
@@ -1,0 +1,5 @@
+inherit tdx-signed-hsm-env
+
+do_compile:prepend() {
+    tdx_signed_hsm_vars_export
+}

--- a/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab.inc
+++ b/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab.inc
@@ -33,6 +33,9 @@ sign_ahab_image() {
     TDX_IMX_HAB_CST_SGK_CERT="${TDX_IMX_HAB_CST_SGK_CERT}" \
     TDX_IMX_HAB_CST_SGK_SUPP="${TDX_IMX_HAB_CST_SGK_SUPP}" \
     TDX_IMX_HAB_CST_TEMPLATE="${TDX_IMX_HAB_CST_TEMPLATE}" \
+    TDX_IMX_HAB_CST_HSM="${TDX_SIGNED_HSM}" \
+    TDX_IMX_HAB_CST_SRK_CA="${TDX_IMX_HAB_CST_SRK_CA}" \
+    TDX_IMX_HAB_CST_SRK_INDEX="${TDX_IMX_HAB_CST_SRK_INDEX}" \
     UNSIGNED_IMAGE="${orig_image}" \
     LOG_MKIMAGE="${logfile}" \
     ${WORKDIR}/mx8_sign.sh -t ${make_target}
@@ -87,8 +90,22 @@ sign_common() {
         bberror "Could not find SRK fuse file '${TDX_IMX_HAB_CST_SRK_FUSE}'."
     fi
 
-    local srk_cert=${TDX_IMX_HAB_CST_SRK_CERT}
-    if [ "${srk_cert##*_ca_}" = "crt.pem" ] && [ "${TDX_IMX_HAB_CST_SGK_SUPP}" = "0" ]; then
+    # show warning if CA flag is enabled but not supported
+    # when an HSM is used, the TDX_IMX_HAB_CST_SRK_CERT is actually a PKCS#11 URI and
+    # cannot be used to check if the CA flag is enabled, so in this case we use the
+    # TDX_IMX_HAB_CST_SRK_CA variable to check if CA is enabled
+    local ca_flag_warn=0
+    if [ "${TDX_SIGNED_HSM}" = "1" ]; then
+        if [ "${TDX_IMX_HAB_CST_SRK_CA}" = "1" ] && [ "${TDX_IMX_HAB_CST_SGK_SUPP}" = "0" ]; then
+            ca_flag_warn=1
+        fi
+    else
+        local srk_cert=${TDX_IMX_HAB_CST_SRK_CERT}
+        if [ "${srk_cert##*_ca_}" = "crt.pem" ] && [ "${TDX_IMX_HAB_CST_SGK_SUPP}" = "0" ]; then
+            ca_flag_warn=1
+        fi
+    fi
+    if [ "${ca_flag_warn}" = "1" ]; then
         bbwarn "AHAB (Secure Boot) signing keys seem to have the CA flag enabled, but" \
                "the build target [${MACHINE}] does not support the use of subordinate" \
                "signing keys. Bootloader will be signed using SRK directly."
@@ -168,3 +185,5 @@ do_deploy:append() {
         install -m 0644 ${WORKDIR}/imx-config.fuse ${DEPLOYDIR}
     fi
 }
+
+require ${@oe.utils.conditional('TDX_SIGNED_HSM', '1', 'imx-boot-hab-hsm.inc', '', d)}


### PR DESCRIPTION
Set up the native PKCS#11/OpenSSL environment required for HSM-backed image signing when TDX_SIGNED_HSM is enabled and adjust the NXP CST image signing script to allow using an HSM via PKCS#11 when signing bootloader images.

Tested on Apalis iMX8 and SMARC iMX95.