### PR TITLE
Build CST from sources with PKCS11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ layers: meta
 branch: scarthgap
 revision: HEAD
 
+URI: git://git.openembedded.org/meta-openembedded
+layers: meta-oe
+branch: scarthgap
+revision: HEAD
+
 URI: git://git.yoctoproject.org/meta-security
 branch: scarthgap
 revision: HEAD

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This layer depends on:
 ```
 URI: git://git.openembedded.org/openembedded-core
 layers: meta
-branch: kirkstone
+branch: scarthgap
 revision: HEAD
 
 URI: git://git.yoctoproject.org/meta-security
-branch: kirkstone
+branch: scarthgap
 revision: HEAD
 ```
 
@@ -27,11 +27,11 @@ This layer recommends:
 
 ```
 URI: git://git.toradex.com/meta-toradex-nxp.git
-branch: kirkstone
+branch: scarthgap
 revision: HEAD
 
 URI: git://git.toradex.com/meta-toradex-ti.git
-branch: kirkstone
+branch: scarthgap
 revision: HEAD
 ```
 

--- a/classes/imx-hab.bbclass
+++ b/classes/imx-hab.bbclass
@@ -6,6 +6,7 @@ TDX_IMX_HAB_CST_DIR ?= "${TOPDIR}/keys/cst"
 # If built from source, recipes needing it must depend on imx-code-signing-tool-native
 # so the tool is present in the native sysroot.
 TDX_IMX_HAB_CST_BUILD_FROM_SOURCE ?= "0"
+TDX_IMX_HAB_CST_BUILD_WITH_PKCS11 ?= "0"
 TDX_IMX_HAB_CST_BIN ?= "${@ '${RECIPE_SYSROOT_NATIVE}/usr/bin/cst' \
                         if d.getVar('TDX_IMX_HAB_CST_BUILD_FROM_SOURCE') == '1' \
                         else '${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst' }"

--- a/classes/imx-hab.bbclass
+++ b/classes/imx-hab.bbclass
@@ -1,8 +1,14 @@
-# NXP CST Tool
-# Cannot be automatically downloaded because it requires a registration
-# Download from https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL_NEW
+# NXP CST Tool root directory
+# Can be downloaded from https://www.nxp.com/webapp/sps/download/license.jsp?colCode=IMX_CST_TOOL_NEW
 TDX_IMX_HAB_CST_DIR ?= "${TOPDIR}/keys/cst"
-TDX_IMX_HAB_CST_BIN ?= "${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst"
+
+# The CST binary can be provided by the user (prebuilt) or built from source.
+# If built from source, recipes needing it must depend on imx-code-signing-tool-native
+# so the tool is present in the native sysroot.
+TDX_IMX_HAB_CST_BUILD_FROM_SOURCE ?= "0"
+TDX_IMX_HAB_CST_BIN ?= "${@ '${RECIPE_SYSROOT_NATIVE}/usr/bin/cst' \
+                        if d.getVar('TDX_IMX_HAB_CST_BUILD_FROM_SOURCE') == '1' \
+                        else '${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst' }"
 
 # additional parameters to be passed to the CST tool
 TDX_IMX_HAB_CST_ARGS ?= ""

--- a/classes/include/signed/tdx-signed-hsm.inc
+++ b/classes/include/signed/tdx-signed-hsm.inc
@@ -29,6 +29,13 @@ UBOOT_MKIMAGE_SIGN_ARGS:append = " -N pkcs11"
 # SoftHSM configuration file
 TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF ?= "${TOPDIR}/keys/softhsm/conf/softhsm2.conf"
 
+# HSM-backed HAB signing requires a CST binary with PKCS#11 support.
+# Since the externally provided CST may not include that support, force
+# the use of a source-built CST and enable its PKCS#11 integration when
+# HAB signing is active.
+TDX_IMX_HAB_CST_BUILD_FROM_SOURCE = "${TDX_IMX_HAB_ENABLE}"
+TDX_IMX_HAB_CST_BUILD_WITH_PKCS11 = "${TDX_IMX_HAB_CST_BUILD_FROM_SOURCE}"
+
 # suppress warning messages from this class
 TDX_SIGNED_HSM_SUPPRESS_WARNINGS ?= "0"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,6 +9,7 @@ BBFILE_PRIORITY_meta-toradex-security = "10"
 
 LAYERDEPENDS_meta-toradex-security = "\
     core \
+    openembedded-layer \
     security \
 "
 

--- a/docs/README-data-partition.md
+++ b/docs/README-data-partition.md
@@ -29,7 +29,7 @@ Additional variables can be used to customize the behavior of this feature:
 | `TDX_TEZI_DATA_PARTITION_MOUNTPOINT` | Directory where the data partition should be mounted | `/data` |
 | `TDX_TEZI_DATA_PARTITION_MOUNT_FLAGS` | Flags used to mount the data partition. See the `mount` man page for more information on the available mount flags | `rw,nosuid,nodev,noatime, errors=remount-ro` |
 
-Additional variables from the `image_type_tezi` class in the `meta-toradex-bsp-common` layer can be used to customize the creation of the data partition. Please see the [source code of this class](https://git.toradex.com/cgit/meta-toradex-bsp-common.git/tree/classes/image_type_tezi.bbclass?h=kirkstone-6.x.y#n37) for more information.
+Additional variables from the `image_type_tezi` class in the `meta-toradex-bsp-common` layer can be used to customize the creation of the data partition. Please see the [source code of this class](https://git.toradex.com/cgit/meta-toradex-bsp-common.git/tree/classes/image_type_tezi.bbclass?h=scarthgap-7.x.y#n38) for more information.
 
 ## Encrypting the data partition
 

--- a/docs/README-secure-boot-imx.md
+++ b/docs/README-secure-boot-imx.md
@@ -25,7 +25,8 @@ After that, configure the various variables listed below to match your choices; 
 | :------- | :---------- | :------------ |
 | `TDX_IMX_HAB_ENABLE` | Enable/disable HAB/AHAB support; allowed values: `0` or `1`. | `1` |
 | `TDX_IMX_HAB_CST_DIR` | Location of the CST tool. | `${TOPDIR}/keys/cst` |
-| `TDX_IMX_HAB_CST_BIN` | Name of the CST binary tool. | `${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst` |
+| `TDX_IMX_HAB_CST_BUILD_FROM_SOURCE` | Build the CST binary tool from source code. Allowed values are: `0` (disabled) or `1` (enabled). | `0` |
+| `TDX_IMX_HAB_CST_BIN` | Name of the CST binary tool. | `${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst` if using prebuilt binary or `${RECIPE_SYSROOT_NATIVE}/usr/bin/cst` if building from source code |
 | `TDX_IMX_HAB_CST_ARGS` | Additional parameters to be passed to the CST tool | Empty |
 | `TDX_IMX_HAB_CST_CERTS_DIR` | Location of the certificates directory. The associated private keys must be located in a directory called `keys` at the same level as the `crts` directory (this is a requirement for the CST tool to work properly). | `${TDX_IMX_HAB_CST_DIR}/crts` |
 | `TDX_IMX_HAB_CST_CRYPTO` | Type of cryptographic keys in use; allowed values: `rsa` or `ecdsa`. This should be set to `ecdsa` if (and only if) you selected "Elliptic Curve Cryptography" when generating the keys/certificates with the CST tool. | `rsa` |

--- a/docs/README-secure-boot-imx.md
+++ b/docs/README-secure-boot-imx.md
@@ -26,6 +26,7 @@ After that, configure the various variables listed below to match your choices; 
 | `TDX_IMX_HAB_ENABLE` | Enable/disable HAB/AHAB support; allowed values: `0` or `1`. | `1` |
 | `TDX_IMX_HAB_CST_DIR` | Location of the CST tool. | `${TOPDIR}/keys/cst` |
 | `TDX_IMX_HAB_CST_BUILD_FROM_SOURCE` | Build the CST binary tool from source code. Allowed values are: `0` (disabled) or `1` (enabled). | `0` |
+| `TDX_IMX_HAB_CST_BUILD_WITH_PKCS11` | Enable PKCS#11 support when building the CST binary from source. This variable is only applicable when `TDX_IMX_HAB_CST_BUILD_FROM_SOURCE` = `1`. Allowed values are: `0` (disabled) or `1` (enabled). | `0` |
 | `TDX_IMX_HAB_CST_BIN` | Name of the CST binary tool. | `${TDX_IMX_HAB_CST_DIR}/linux64/bin/cst` if using prebuilt binary or `${RECIPE_SYSROOT_NATIVE}/usr/bin/cst` if building from source code |
 | `TDX_IMX_HAB_CST_ARGS` | Additional parameters to be passed to the CST tool | Empty |
 | `TDX_IMX_HAB_CST_CERTS_DIR` | Location of the certificates directory. The associated private keys must be located in a directory called `keys` at the same level as the `crts` directory (this is a requirement for the CST tool to work properly). | `${TDX_IMX_HAB_CST_DIR}/crts` |

--- a/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab.inc
+++ b/dynamic-layers/freescale/recipes-bsp/imx-mkimage/imx-boot-hab.inc
@@ -5,6 +5,9 @@ inherit imx-hab
 # Need this for the create_fuse_cmds.sh script
 DEPENDS += "imx-fuses-native"
 
+# build CST binary from sources
+DEPENDS += "${@ 'imx-code-signing-tool-native' if d.getVar('TDX_IMX_HAB_CST_BUILD_FROM_SOURCE') == '1' else '' }"
+
 SRC_URI:append = "\
     file://mx8_sign.sh \
     file://mx8_template.csf \

--- a/recipes-bsp/imx-code-signing-tool/imx-code-signing-tool-native-pkcs11.inc
+++ b/recipes-bsp/imx-code-signing-tool/imx-code-signing-tool-native-pkcs11.inc
@@ -1,0 +1,26 @@
+DEPENDS += "libp11-native patchelf-native"
+
+EXTRA_OECMAKE:append = "\
+    -DCST_WITH_PKCS11=ON \
+    -Dlibp11_DIR=/usr/lib/engines-3 \
+"
+
+do_configure:prepend() {
+    # CST's CMakeLists forces static OpenSSL (OPENSSL_USE_STATIC_LIBS=TRUE). This breaks PKCS#11/HSM use
+    # because the PKCS#11 stack (engine_pkcs11/libp11 + vendor module like YKCS11/SoftHSM) is dynamically
+    # linked to libcrypto.so, leading to two OpenSSL instances in the same process and CST crashes (SIGSEGV).
+    # Force dynamic OpenSSL linking so CST and the PKCS#11 engine/module share the same libcrypto/libssl.
+    sed -i 's/set(OPENSSL_USE_STATIC_LIBS TRUE)/set(OPENSSL_USE_STATIC_LIBS FALSE)/' \
+        ${S}/src/CMakeLists.txt
+
+    # CST hardcodes the PKCS#11 dependency to a static archive (libpkcs11.a). In OE, we may only have the
+    # shared lib available; allow CMake to resolve either libpkcs11.so or libpkcs11.a by searching for "pkcs11"
+    sed -i 's/find_cst_dependency_library("libpkcs11\.a"/find_cst_dependency_library("pkcs11"/' \
+        ${S}/src/CMakeLists.txt
+}
+
+do_install:append() {
+    # CST is linked against the OpenSSL pkcs11 engine (pkcs11.so), which lives in ${libdir}/engines-3.
+    # Add that directory to RUNPATH so the dynamic loader can resolve pkcs11.so at startup.
+    patchelf --set-rpath '$ORIGIN/../lib:$ORIGIN/../lib/engines-3:$ORIGIN/../../lib' ${D}${bindir}/cst
+}

--- a/recipes-bsp/imx-code-signing-tool/imx-code-signing-tool-native_4.0.1.bb
+++ b/recipes-bsp/imx-code-signing-tool/imx-code-signing-tool-native_4.0.1.bb
@@ -1,0 +1,24 @@
+SUMMARY = "i.MX High Assurance Boot Reference Code Signing Tool"
+DESCRIPTION = "NXP Code Signing Tool for the High Assurance Boot library. \
+Provides software code signing support designed for use with i.MX processors \
+that integrate the HAB library in the internal boot ROM"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://COPYING;md5=dc56c17219895403ffc9aea66e228c8c"
+
+DEPENDS = "openssl-native bison-native flex-native json-c-native"
+
+SRC_URI = "\
+    git://github.com/toradex/imx-code-signing-tool.git;protocol=https;branch=main \
+"
+
+SRCREV = "8931a2f536205a76c3f1778b02df857426291090"
+
+S = "${WORKDIR}/git"
+OECMAKE_SOURCEPATH = "${S}/src"
+
+EXTRA_OECMAKE:append = "\
+    -DCMAKE_C_FLAGS='${CFLAGS} -Wno-error=unused-result' \
+"
+
+inherit cmake native

--- a/recipes-bsp/imx-code-signing-tool/imx-code-signing-tool-native_4.0.1.bb
+++ b/recipes-bsp/imx-code-signing-tool/imx-code-signing-tool-native_4.0.1.bb
@@ -22,3 +22,5 @@ EXTRA_OECMAKE:append = "\
 "
 
 inherit cmake native
+
+require ${@oe.utils.conditional('TDX_IMX_HAB_CST_BUILD_WITH_PKCS11', '1', 'imx-code-signing-tool-native-pkcs11.inc', '', d)}

--- a/recipes-bsp/u-boot/u-boot-hab.inc
+++ b/recipes-bsp/u-boot/u-boot-hab.inc
@@ -9,6 +9,9 @@ DEPENDS += "xxd-native dtc-native"
 # Need this to create deterministic CSF binaries when running the NXP Code Signing Tool
 DEPENDS += "libfaketime-native"
 
+# build CST binary from sources
+DEPENDS += "${@ 'imx-code-signing-tool-native' if d.getVar('TDX_IMX_HAB_CST_BUILD_FROM_SOURCE') == '1' else '' }"
+
 SRC_URI:append = "\
     file://u-boot-hab.cfg \
 "


### PR DESCRIPTION
This pull request adds support for building the NXP i.MX Code Signing Tool (CST) from source and, optionally, enabling PKCS#11 support for it. The goal is to make HAB/AHAB signing workflows less dependent on externally installed CST binaries, improve control over the CST version used during signing, and allow CST to be rebuilt with extra capabilities (e.g. PKCS#11 support required for HSM-based signing flows).

The changes were tested with the following configurations:

- Verdin iMX8MM with secure boot enabled and HSM-backed keys using SoftHSM
- Verdin iMX8MP with secure boot enabled and HSM-backed keys using a YubiKey
- Colibri iMX6 with secure boot enabled and filesystem-backed keys