### PR TITLE
tdx-reference-ramdisk-image.bb: fix do_rootfs dependency definition

### DIFF
--- a/recipes-images/images/tdx-reference-ramdisk-image.bb
+++ b/recipes-images/images/tdx-reference-ramdisk-image.bb
@@ -45,7 +45,7 @@ DEPENDS:remove = "\
 
 # rootfs should be built before the ramdisk so we have
 # dm-verity.env to add to the ramdisk
-do_rootfs[depends] += "${DM_VERITY_IMAGE}:do_image_${DM_VERITY_IMAGE_TYPE}"
+do_rootfs[depends] += "${DM_VERITY_IMAGE}:do_image_${@d.getVar('DM_VERITY_IMAGE_TYPE').replace('-', '_')}"
 
 # ensure dm-verity.env is updated also when rebuilding DM_VERITY_IMAGE
 do_image[nostamp] = "1"


### PR DESCRIPTION
In tdx-reference-ramdisk-image.bb, you can't use DM_VERITY_IMAGE_TYPE directly to set do_rootfs dependencies:

do_rootfs[depends] += "${DM_VERITY_IMAGE}:do_image_${DM_VERITY_IMAGE_TYPE}"

This breaks when DM_VERITY_IMAGE_TYPE contains a hyphen, as in: DM_VERITY_IMAGE_TYPE ?= "erofs-lz4hc"

In this case, as the task name is "do_image_erofs_lz4hc", we need to use "erofs_lz4hc" instead of "erofs-lz4hc", and keep setting DM_VERITY_IMAGE_TYPE to "erofs-lz4hc", otherwise we would have a wrong setting for IMAGE_TYPES.

Without this change, you get this failure:

ERROR: Task do_populate_sdk in .../meta-toradex-security/recipes-images/images/tdx-reference-ramdisk-image.bb depends upon non-existent task do_image_erofs-lz4hc in ...

The problem should happen with all IMAGE_TYPES with an hyphen:
- erofs-lz4
- erofs-lz4hc
- squashfs-lz4
- squashfs-lzo
- squashfs-xz