### PR TITLE
tdx-reference-ramdisk-image: fix undefined variable case

### DIFF
--- a/recipes-images/images/tdx-reference-ramdisk-image.bb
+++ b/recipes-images/images/tdx-reference-ramdisk-image.bb
@@ -45,7 +45,7 @@ DEPENDS:remove = "\
 
 # rootfs should be built before the ramdisk so we have
 # dm-verity.env to add to the ramdisk
-do_rootfs[depends] += "${DM_VERITY_IMAGE}:do_image_${@d.getVar('DM_VERITY_IMAGE_TYPE').replace('-', '_')}"
+do_rootfs[depends] += "${DM_VERITY_IMAGE}:do_image_${@ (d.getVar('DM_VERITY_IMAGE_TYPE') or '').replace('-', '_')}"
 
 # ensure dm-verity.env is updated also when rebuilding DM_VERITY_IMAGE
 do_image[nostamp] = "1"


### PR DESCRIPTION
0e08b8d3ed: tdx-reference-ramdisk-image.bb: fix do_rootfs dependency definition introduced a regression when the DM_VERITY_IMAGE_TYPE variable is not defined, typically when dm-verity is not enabled.

In this case, the statement:
@d.getVar('DM_VERITY_IMAGE_TYPE').replace('-', '_') errors with this message:
AttributeError: 'NoneType' object has no attribute 'replace'

tdx-reference-ramdisk-image.bb is only relevant when the "tdxref-signed" class is inherited, but it is parsed in any case.

Add "or ''" to the expression, to make sure the result is always a string, on which the replace() operator can be applied.

Tested in both cases: DM_VERITY_IMAGE_TYPE defined and not defined.