### PR TITLE
A few improvements and fixes for the encryption feature

### DIFF
--- a/docs/README-encryption.md
+++ b/docs/README-encryption.md
@@ -138,6 +138,14 @@ To confirm you have a TPM to be used as a Trust Source for managing the encrypti
 
 If your hardware lacks a discrete TPM chip, you may want to consider using an fTPM (firmware-based TPM) running in OP-TEE. For additional details, please refer to the [fTPM session in the OP-TEE documentation](README-optee.md#ftpm-support-in-op-tee).
 
+The encryption key can only be unsealed by the same TPM that created it. This protects the encrypted data against offline attacks, such as removing the storage device and accessing it on another machine. Because the key blob is bound to a specific TPM, it cannot be migrated to another device. If the TPM is replaced or its owner hierarchy is cleared (e.g., via tpm2_clear), the key blob becomes unrecoverable and the encrypted partition must be reinitialized, resulting in data loss.
+
+In the current implementation, there is no support for an authorization policy (e.g., binding the key to the state of the boot chain). As a result, any code running on the device with sufficient access to the TPM can unseal the key, regardless of the boot state.
+
+Enabling secure boot mitigates this risk by ensuring that only authenticated and trusted software is executed, making it harder for an attacker to run arbitrary code with access to the TPM. However, without an authorization policy, a physical attacker could still attempt hardware-level attacks, such as removing the TPM device to extract secrets.
+
+Binding the key to Platform Configuration Registers (PCRs), thereby tying it to the measured boot chain, is planned for a future implementation.
+
 ## Notes on using TEE
 
 Before enabling the TEE backend, ensure that a Trusted Execution Environment (such as OP-TEE) is properly configured and enabled on your platform.

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
@@ -109,9 +109,19 @@ tdx_enc_prepare_generic() {
 
     TDX_ENC_STORAGE_NUM_BLOCKS=$(blockdev --getsz ${TDX_ENC_STORAGE_LOCATION})
     if [ "${TDX_ENC_KEY_LOCATION}" = "partition" ] && [ "${TDX_ENC_STORAGE_RESERVE}" = "0" ]; then
-        # we need at least one reserved block to store the encryption key blob
-        TDX_ENC_STORAGE_RESERVE="1"
+        if [ "${TDX_ENC_CIPHER}" = "aes-cbc" ]; then
+            TDX_ENC_STORAGE_RESERVE="1"
+        else
+            TDX_ENC_STORAGE_RESERVE="4"
+        fi
     fi
+
+    if [ "${TDX_ENC_KEY_LOCATION}" = "partition" ] && [ "${TDX_ENC_CIPHER}" = "aes-xts" ]; then
+        if [ "${TDX_ENC_STORAGE_RESERVE}" -lt 2 ]; then
+            tdx_enc_exit_error "TDX_ENC_STORAGE_RESERVE must be at least 2 when using aes-xts with partition key location!"
+        fi
+    fi
+
     TDX_ENC_STORAGE_NUM_BLOCKS=$((TDX_ENC_STORAGE_NUM_BLOCKS - TDX_ENC_STORAGE_RESERVE))
 
     tdx_enc_log "Blocks to be encrypted: $TDX_ENC_STORAGE_NUM_BLOCKS..."
@@ -177,7 +187,7 @@ tdx_enc_key_recover_from_partition() {
     rm -rf $TDX_ENC_KEY_FULLPATH
 
     STORAGE_KEY_BLOCK_DATA=$(mktemp /tmp/tdx-enc.XXXXXXXXXX)
-    if ! dd if=${TDX_ENC_STORAGE_LOCATION} of=${STORAGE_KEY_BLOCK_DATA} skip=${TDX_ENC_STORAGE_NUM_BLOCKS} bs=512 count=1; then
+    if ! dd if=${TDX_ENC_STORAGE_LOCATION} of=${STORAGE_KEY_BLOCK_DATA} skip=${TDX_ENC_STORAGE_NUM_BLOCKS} bs=512 count=${TDX_ENC_STORAGE_RESERVE}; then
         rm -f "${STORAGE_KEY_BLOCK_DATA}"
         tdx_enc_exit_error "Could not read block from ${TDX_ENC_STORAGE_LOCATION} with key information!"
     fi

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
@@ -354,7 +354,7 @@ tdx_run_user_check() {
     if [ -x ${TDX_ENC_USER_SCRIPT} ]; then
         if ! [ -O ${TDX_ENC_USER_SCRIPT} -a -G ${TDX_ENC_USER_SCRIPT} ]; then
             tdx_enc_log "WARNING: Ignoring user check script due to invalid ownership."
-        elif (( 0$(stat -c %a "${TDX_ENC_USER_SCRIPT}") & 07022 )); then
+        elif [ $(( 0$(stat -c %a "${TDX_ENC_USER_SCRIPT}") & 07022 )) -ne 0 ]; then
             tdx_enc_log "WARNING: Ignoring user check script due to invalid permissions."
         elif ! ${TDX_ENC_USER_SCRIPT}; then
             tdx_enc_exit_error "Encryption disabled by the user!"

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
@@ -258,9 +258,12 @@ tdx_enc_keyring_configure() {
         tdx_enc_log "Key blob not found. Creating it..."
         KEYHANDLE="$(keyctl add "${TDX_ENC_KEY_KEYRING_TYPE}" "${KEYNAME}" "$(eval echo ${NEW_KEY_CMD})" @s)"
         mkdir -p "${TDX_ENC_KEY_DIR}"
-        if ! keyctl pipe "$KEYHANDLE" > "${TDX_ENC_KEY_FULLPATH}"; then
+        TDX_ENC_KEY_TMPPATH=$(mktemp "${TDX_ENC_KEY_DIR}/tdx-enc.XXXXXXXXXX")
+        if ! keyctl pipe "$KEYHANDLE" > "${TDX_ENC_KEY_TMPPATH}"; then
+            rm -f "${TDX_ENC_KEY_TMPPATH}"
             tdx_enc_exit_error "Error saving key blob!"
         fi
+        mv "${TDX_ENC_KEY_TMPPATH}" "${TDX_ENC_KEY_FULLPATH}"
         if [ "${TDX_ENC_KEY_LOCATION}" = "partition" ]; then
             tdx_enc_key_save_to_partition
             rm -f "${TDX_ENC_KEY_FULLPATH}"

--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
@@ -176,8 +176,9 @@ tdx_enc_key_recover_from_partition() {
     TDX_ENC_KEY_FULLPATH="/tmp/${TDX_ENC_KEY_FILE}"
     rm -rf $TDX_ENC_KEY_FULLPATH
 
-    STORAGE_KEY_BLOCK_DATA=/tmp/.enckey.txt
+    STORAGE_KEY_BLOCK_DATA=$(mktemp /tmp/tdx-enc.XXXXXXXXXX)
     if ! dd if=${TDX_ENC_STORAGE_LOCATION} of=${STORAGE_KEY_BLOCK_DATA} skip=${TDX_ENC_STORAGE_NUM_BLOCKS} bs=512 count=1; then
+        rm -f "${STORAGE_KEY_BLOCK_DATA}"
         tdx_enc_exit_error "Could not read block from ${TDX_ENC_STORAGE_LOCATION} with key information!"
     fi
 
@@ -192,6 +193,7 @@ tdx_enc_key_recover_from_partition() {
             "keycsum") keycsum="${val}" ;;
         esac
     done < ${STORAGE_KEY_BLOCK_DATA}
+    rm -f "${STORAGE_KEY_BLOCK_DATA}"
 
     if [ "${keyname}" != "${TDX_ENC_KEY_KEYRING_NAME}" ]; then
         tdx_enc_log "Invalid key name! A new key will be created."
@@ -216,7 +218,7 @@ tdx_enc_key_recover_from_partition() {
 tdx_enc_key_save_to_partition() {
     tdx_enc_log "Saving encrypted key to partition ${TDX_ENC_STORAGE_LOCATION}..."
 
-    STORAGE_KEY_BLOCK_DATA="/tmp/.enckey.txt"
+    STORAGE_KEY_BLOCK_DATA=$(mktemp /tmp/tdx-enc.XXXXXXXXXX)
     {
         echo "keyname=${TDX_ENC_KEY_KEYRING_NAME}"
         echo "keydata=$(cat ${TDX_ENC_KEY_FULLPATH})"
@@ -225,8 +227,10 @@ tdx_enc_key_save_to_partition() {
     } > ${STORAGE_KEY_BLOCK_DATA}
 
     if ! dd if=${STORAGE_KEY_BLOCK_DATA} of=${TDX_ENC_STORAGE_LOCATION} seek=${TDX_ENC_STORAGE_NUM_BLOCKS} bs=512; then
+        rm -f "${STORAGE_KEY_BLOCK_DATA}"
         tdx_enc_exit_error "Could not save encrypted key to partition ${TDX_ENC_STORAGE_LOCATION}!"
     fi
+    rm -f "${STORAGE_KEY_BLOCK_DATA}"
 }
 
 # configure key in kernel keyring
@@ -249,10 +253,14 @@ tdx_enc_keyring_configure() {
         fi
         if [ "${TDX_ENC_KEY_LOCATION}" = "partition" ]; then
             tdx_enc_key_save_to_partition
+            rm -f "${TDX_ENC_KEY_FULLPATH}"
         fi
     else
         tdx_enc_log "Encrypted key exists. Importing it..."
         keyctl add "${TDX_ENC_KEY_KEYRING_TYPE}" "${KEYNAME}" "$(eval echo ${LOAD_KEY_CMD})" @s
+        if [ "${TDX_ENC_KEY_LOCATION}" = "partition" ]; then
+            rm -f "${TDX_ENC_KEY_FULLPATH}"
+        fi
     fi
 
     if ! keyctl list @s | grep -q "${TDX_ENC_KEY_KEYRING_TYPE}: ${KEYNAME}"; then
@@ -284,14 +292,17 @@ tdx_enc_key_gen_tpm() {
     tdx_enc_log "Setting up encryption key for TPM backend..."
 
     if [ ! -e "${TDX_ENC_KEY_FULLPATH}" ]; then
+        TPM_KEY_CTXT=$(mktemp /tmp/tdx-enc.XXXXXXXXXX)
 
         # create a private RSA key in the TPM
-        if ! tpm2_createprimary -C o -G rsa2048 -c /tmp/key.ctxt; then
+        if ! tpm2_createprimary -C o -G rsa2048 -c "${TPM_KEY_CTXT}"; then
+            rm -f "${TPM_KEY_CTXT}"
             tdx_enc_exit_error "Error creating a private RSA key in the TPM!"
         fi
 
         # make the key persistent
-        TPMKEYHANDLE=$(tpm2_evictcontrol -C o -c /tmp/key.ctxt | grep persistent-handle | cut -d' ' -f 2)
+        TPMKEYHANDLE=$(tpm2_evictcontrol -C o -c "${TPM_KEY_CTXT}" | grep persistent-handle | cut -d' ' -f 2)
+        rm -f "${TPM_KEY_CTXT}"
         if [ -z "$TPMKEYHANDLE" ]; then
             tdx_enc_exit_error "Error making the TPM key persistent!"
         fi


### PR DESCRIPTION
Fixes a few bugs and implement some improvements of the data-at-rest encryption feature:

1. Fix POSIX sh incompatibility in the encryption handler script.
2. Remove temporary files used to create key material after usage.
3. Fix a critical issue when recovering the key when using AES-XTS cipher mode.
4. Document TPM backend limitations
5. Make sure the key blob (wrapped key) is written attomically in the filesystem.

Itens 1, 2 and 5 were reported by Claude.

Build and runtime tested on Verdin iMX8MP.