### PR TITLE
tdx-enc-handler: fix wrapped key creation on read-only rootfs

### DIFF
--- a/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
+++ b/recipes-core/tdx-enc-handler/tdx-enc-handler/tdx-enc.sh
@@ -128,6 +128,8 @@ tdx_enc_prepare_generic() {
     tdx_enc_log "Reserved blocks: $TDX_ENC_STORAGE_RESERVE..."
 
     if [ "${TDX_ENC_KEY_LOCATION}" = "partition" ]; then
+        TDX_ENC_KEY_DIR="/tmp"
+        TDX_ENC_KEY_FULLPATH="${TDX_ENC_KEY_DIR}/${TDX_ENC_KEY_FILE}"
         tdx_enc_key_recover_from_partition
     fi
 }
@@ -183,7 +185,6 @@ tdx_enc_prepare_tee() {
 tdx_enc_key_recover_from_partition() {
     tdx_enc_log "Recovering encrypted key blob from partition ${TDX_ENC_STORAGE_LOCATION}..."
 
-    TDX_ENC_KEY_FULLPATH="/tmp/${TDX_ENC_KEY_FILE}"
     rm -rf $TDX_ENC_KEY_FULLPATH
 
     STORAGE_KEY_BLOCK_DATA=$(mktemp /tmp/tdx-enc.XXXXXXXXXX)


### PR DESCRIPTION
When `TDX_ENC_KEY_LOCATION="partition"` is used on a system with a read-only rootfs (for example, with `dm-verity`), creating a new wrapped key fails with:

```
caam: ERROR: Error saving key blob!
```

This is a regression introduced by commit 79002ecf9229 ("tdx-enc-handler: write key blob atomically"), and happens because mkdir/mktemp cannot write to `TDX_ENC_KEY_DIR` (default `/var/local/private/.keys`).

Fix this by always setting both `TDX_ENC_KEY_DIR` and `TDX_ENC_KEY_FULLPATH` to `/tmp` when `TDX_ENC_KEY_LOCATION="partition"`.

Tested with both `TDX_ENC_KEY_LOCATION="partition"` and `TDX_ENC_KEY_LOCATION="filesystem"`, to make sure there are no further regressions.