### PR TITLE
u-boot-distro-boot-harden: fix bug with root argument amendment

### DIFF
--- a/recipes-bsp/u-boot/u-boot-distro-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-distro-boot-harden.inc
@@ -62,11 +62,11 @@ amend_console_argument() {
 
 amend_root_argument() {
     # Sanity checks:
-    if ! grep -q 'env set rootfsargs_set'; then
+    if ! grep -q 'env set rootfsargs_set' boot.cmd; then
         bbfatal "Amendments to bootscript must be reviewed: statement setting variable 'rootfsargs_set' wasn't found."
     fi
 
-    if ! grep -q 'env set bootcmd_args'; then
+    if ! grep -q 'env set bootcmd_args' boot.cmd; then
         bbfatal "Amendments to bootscript must be reviewed: statement setting variable 'bootcmd_args' wasn't found."
     fi
 


### PR DESCRIPTION
Add missing argument to a grep invocation which was introduced by the commit titled "u-boot-distro-boot-harden: make individual amendments configurable".

Related-to: TOR-4240