### PR TITLE
Add HSM-backed signing support for TI K3 boot containers

### DIFF
--- a/classes/include/signed/tdx-signed-hsm-imx.inc
+++ b/classes/include/signed/tdx-signed-hsm-imx.inc
@@ -1,0 +1,6 @@
+# HSM-backed HAB signing requires a CST binary with PKCS#11 support.
+# Since the externally provided CST may not include that support, force
+# the use of a source-built CST and enable its PKCS#11 integration when
+# HAB signing is active.
+TDX_IMX_HAB_CST_BUILD_FROM_SOURCE = "${TDX_IMX_HAB_ENABLE}"
+TDX_IMX_HAB_CST_BUILD_WITH_PKCS11 = "${TDX_IMX_HAB_CST_BUILD_FROM_SOURCE}"

--- a/classes/include/signed/tdx-signed-hsm-k3.inc
+++ b/classes/include/signed/tdx-signed-hsm-k3.inc
@@ -1,0 +1,16 @@
+# PKCS#11 URI of the private key used by binman to sign the TI K3 boot container
+# Example: "pkcs11:token=k3-hsm;object=custMpk;type=private"
+TDX_SIGNED_HSM_K3_BINMAN_KEY_URL ?= ""
+
+# Path to an OpenSSL configuration file activating the pkcs11 provider.
+# When empty, one is generated automatically at build time using the
+# PKCS#11 module path declared in TDX_SIGNED_HSM_PKCS11_MODULE_PATH.
+TDX_SIGNED_HSM_K3_OPENSSL_CONF ?= ""
+
+addhandler validate_hsm_configuration_k3
+validate_hsm_configuration_k3[eventmask] = "bb.event.SanityCheck"
+python validate_hsm_configuration_k3() {
+    if e.data.getVar("TDX_SIGNED_HSM_K3_BINMAN_KEY_URL") == "":
+        bb.fatal("PKCS#11 URI to sign the TI K3 boot container is not set. " \
+                "Please configure it via TDX_SIGNED_HSM_K3_BINMAN_KEY_URL variable.")
+}

--- a/classes/include/signed/tdx-signed-hsm.inc
+++ b/classes/include/signed/tdx-signed-hsm.inc
@@ -29,12 +29,8 @@ UBOOT_MKIMAGE_SIGN_ARGS:append = " -N pkcs11"
 # SoftHSM configuration file
 TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF ?= "${TOPDIR}/keys/softhsm/conf/softhsm2.conf"
 
-# HSM-backed HAB signing requires a CST binary with PKCS#11 support.
-# Since the externally provided CST may not include that support, force
-# the use of a source-built CST and enable its PKCS#11 integration when
-# HAB signing is active.
-TDX_IMX_HAB_CST_BUILD_FROM_SOURCE = "${TDX_IMX_HAB_ENABLE}"
-TDX_IMX_HAB_CST_BUILD_WITH_PKCS11 = "${TDX_IMX_HAB_CST_BUILD_FROM_SOURCE}"
+# NXP imx-specific HSM configuration
+require ${@ 'tdx-signed-hsm-imx.inc' if 'imx-generic-bsp' in d.getVar('MACHINEOVERRIDES_EXTENDER').split(':') else ''}
 
 # suppress warning messages from this class
 TDX_SIGNED_HSM_SUPPRESS_WARNINGS ?= "0"

--- a/classes/include/signed/tdx-signed-hsm.inc
+++ b/classes/include/signed/tdx-signed-hsm.inc
@@ -22,8 +22,8 @@ TDX_SIGNED_HSM_FIT_TOKEN_LABEL ?= ""
 
 # FIT image configuration to use the HSM for signing
 FIT_GENERATE_KEYS = "0"
-UBOOT_SIGN_KEYDIR = "${TDX_SIGNED_HSM_FIT_TOKEN_URL}"
-UBOOT_SIGN_KEYNAME = "${TDX_SIGNED_HSM_FIT_TOKEN_LABEL}"
+UBOOT_SIGN_KEYDIR:forcevariable = "${TDX_SIGNED_HSM_FIT_TOKEN_URL}"
+UBOOT_SIGN_KEYNAME:forcevariable = "${TDX_SIGNED_HSM_FIT_TOKEN_LABEL}"
 UBOOT_MKIMAGE_SIGN_ARGS:append = " -N pkcs11"
 
 # SoftHSM configuration file
@@ -31,6 +31,10 @@ TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF ?= "${TOPDIR}/keys/softhsm/conf/softhsm2.conf
 
 # NXP imx-specific HSM configuration
 require ${@ 'tdx-signed-hsm-imx.inc' if 'imx-generic-bsp' in d.getVar('MACHINEOVERRIDES_EXTENDER').split(':') else ''}
+
+# TI k3-specific HSM configuration
+require ${@ 'tdx-signed-hsm-k3.inc' if 'k3r5' in d.getVar('OVERRIDES').split(':') else ''}
+require ${@ 'tdx-signed-hsm-k3.inc' if 'k3' in d.getVar('OVERRIDES').split(':') else ''}
 
 # suppress warning messages from this class
 TDX_SIGNED_HSM_SUPPRESS_WARNINGS ?= "0"

--- a/classes/tdx-signed-hsm-env.bbclass
+++ b/classes/tdx-signed-hsm-env.bbclass
@@ -1,10 +1,27 @@
 DEPENDS:append = "\
     openssl-native \
     libp11-native \
+    pkcs11-provider-native \
     ${TDX_SIGNED_HSM_PKCS11_MODULE_PROVIDER} \
 "
 
+tdx_signed_hsm_vars_export_common() {
+    # HSM token PIN
+    if [ -z "${TDX_SIGNED_HSM_TOKEN_PIN}" ]; then
+        bbfatal "Missing PIN to access the HSM. Please configure it via TDX_SIGNED_HSM_TOKEN_PIN variable."
+    fi
+
+    # SoftHSM configuration
+    if echo ${TDX_SIGNED_HSM_PKCS11_MODULE_PATH} | grep -q 'libsofthsm2.so'; then
+        [ -r "${TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF}" ] || bbfatal "Cannot access SoftHSM configuration file: ${TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF}"
+        export SOFTHSM2_CONF="${TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF}"
+    fi
+}
+
 tdx_signed_hsm_vars_export() {
+    # common configuration
+    tdx_signed_hsm_vars_export_common
+
     # OpenSSL engines directory
     for d in \
         "${RECIPE_SYSROOT_NATIVE}${libdir}/engines-3" \
@@ -18,18 +35,52 @@ tdx_signed_hsm_vars_export() {
     [ -d "${OPENSSL_ENGINES}" ] || bbfatal "OpenSSL engines directory not found in native sysroot."
 
     # HSM token PIN
-    if [ -z "${TDX_SIGNED_HSM_TOKEN_PIN}" ]; then
-        bbfatal "Missing PIN to access the HSM. Please configure it via TDX_SIGNED_HSM_TOKEN_PIN variable."
-    fi
     export MKIMAGE_SIGN_PIN="${TDX_SIGNED_HSM_TOKEN_PIN}"
 
     # PKCS#11 module
     export PKCS11_MODULE_PATH="${RECIPE_SYSROOT_NATIVE}/${TDX_SIGNED_HSM_PKCS11_MODULE_PATH}"
     [ -r "${PKCS11_MODULE_PATH}" ] || bbfatal "PKCS#11 module missing or not readable: ${PKCS11_MODULE_PATH}"
+}
 
-    # SoftHSM configuration
-    if echo ${TDX_SIGNED_HSM_PKCS11_MODULE_PATH} | grep -q 'libsofthsm2.so'; then
-        [ -r "${TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF}" ] || bbfatal "Cannot access SoftHSM configuration file: ${TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF}"
-        export SOFTHSM2_CONF="${TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF}"
+# Set up the environment so binman can sign TI K3 boot containers via a key stored in an HSM
+tdx_signed_hsm_vars_export_k3_binman() {
+    # common configuration
+    tdx_signed_hsm_vars_export_common
+
+    # binman x509_cert key URI
+    if [ -z "${TDX_SIGNED_HSM_K3_BINMAN_KEY_URL}" ]; then
+        bbfatal "Missing PKCS#11 URI for K3 binman signing. Please configure it via TDX_SIGNED_HSM_K3_BINMAN_KEY_URL variable."
     fi
+
+    # OpenSSL configuration: use user-supplied file if available, otherwise generate one
+    if [ -n "${TDX_SIGNED_HSM_K3_OPENSSL_CONF}" ]; then
+        [ -r "${TDX_SIGNED_HSM_K3_OPENSSL_CONF}" ] || bbfatal "Cannot read OpenSSL configuration file: ${TDX_SIGNED_HSM_K3_OPENSSL_CONF}"
+        export OPENSSL_CONF="${TDX_SIGNED_HSM_K3_OPENSSL_CONF}"
+    else
+        pkcs11_module="${RECIPE_SYSROOT_NATIVE}/${TDX_SIGNED_HSM_PKCS11_MODULE_PATH}"
+        [ -r "${pkcs11_module}" ] || bbfatal "PKCS#11 module missing or not readable: ${pkcs11_module}"
+        cat > "${WORKDIR}/openssl-pkcs11.cnf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+pkcs11-module-path = ${pkcs11_module}
+pkcs11-module-quirks = no-deinit
+activate = 1
+EOF
+        export OPENSSL_CONF="${WORKDIR}/openssl-pkcs11.cnf"
+    fi
+
+    # binman x509_cert key URI and PIN
+    export BINMAN_X509_KEY_URI="${TDX_SIGNED_HSM_K3_BINMAN_KEY_URL}"
+    export PKCS11_PIN="${TDX_SIGNED_HSM_TOKEN_PIN}"
 }

--- a/docs/README-secure-boot-hsm.md
+++ b/docs/README-secure-boot-hsm.md
@@ -4,7 +4,7 @@ This document describes how to use a PKCS#11-compatible HSM to sign secure-boot 
 
 With this workflow, private signing keys do not need to be stored on the build host filesystem. Instead, signing operations are delegated through a PKCS#11 provider to an HSM-backed device or service, such as a hardware token or a CloudHSM offering.
 
-The current implementation supports HSM-backed signing for the complete secure boot flow on i.MX-based SoMs. Support for TI-based SoMs is still a work in progress.
+The implementation supports HSM-backed signing for the complete secure boot flow on both i.MX-based and TI K3-based SoMs.
 
 ## How to use
 
@@ -41,6 +41,8 @@ The following variables are available to configure HSM-backed signing of secure 
 | `TDX_SIGNED_HSM_PKCS11_MODULE_PROVIDER` | Native package that provides the PKCS#11 implementation for the HSM. It is added as a dependency to recipes that need to access the token during signing. | `""` |
 | `TDX_SIGNED_HSM_PKCS11_MODULE_PATH` | Path to the PKCS#11 shared library, relative to the recipe native sysroot. | `""` |
 | `TDX_SIGNED_HSM_PKCS11_SOFTHSM_CONF` | Path to the SoftHSM configuration file. This is required when using SoftHSM, a software implementation of a PKCS#11 token commonly used for development and testing. | `${TOPDIR}/keys/softhsm/conf/softhsm2.conf` |
+| `TDX_SIGNED_HSM_K3_BINMAN_KEY_URL` | PKCS#11 URI of the private key used by binman to sign the TI K3 boot container. Only relevant when targeting a TI K3 SoM. | `""` |
+| `TDX_SIGNED_HSM_K3_OPENSSL_CONF` | Path to an OpenSSL configuration file activating the `pkcs11` provider, used when signing the TI K3 boot container. If empty, one is generated automatically at build time. | `""` |
 | `TDX_SIGNED_HSM_FIT_TOKEN_URL` | PKCS#11 URI identifying the token that contains the FIT signing key. | `""` |
 | `TDX_SIGNED_HSM_FIT_TOKEN_LABEL` | Label of the private key object used to sign the FIT image. | `""` |
 | `TDX_SIGNED_HSM_SUPPRESS_WARNINGS` | Suppress sanity-check warnings emitted when HSM variables are missing. Allowed values are `0` and `1`. | `0` |
@@ -58,7 +60,7 @@ The most important variables for configuring the PKCS#11 provider are `TDX_SIGNE
 The HSM signing flow in `meta-toradex-security` is designed to be provider-agnostic, as long as the HSM is accessible through a PKCS#11-compatible shared library available in the native sysroot. At the moment, the layer has been validated with the following providers:
 
 - **SoftHSM**, a software implementation of a PKCS#11 token.
-- **YubiKey**, a hardware-backed signing device from [Yubico](https://www.yubico.com/).
+- **YubiKey 5 NFC**, a hardware-backed signing device from [Yubico](https://www.yubico.com/).
 
 SoftHSM is useful for development, testing, and CI because it provides a PKCS#11-compatible software token without requiring dedicated hardware. Example configuration:
 
@@ -84,7 +86,7 @@ To use a different PKCS#11 provider, the layer does not usually require code cha
 
 > **Note:** If the provider requires additional environment variables or runtime initialization, the build logic may need to be extended accordingly. For a reference, see `classes/tdx-signed-hsm-env.bbclass`.
 
-### Configuring HAB/AHAB signing (only for NXP iMX based SoMs)
+### Configuring HAB/AHAB signing for NXP i.MX-based SoMs
 
 When signing boot images for NXP i.MX platforms with HAB or AHAB enabled, CST normally expects the signing certificates to be provided as files on the build host filesystem.
 
@@ -120,7 +122,45 @@ In these examples:
 
 This configuration changes how CST locates the certificate objects. It does not change the role of each variable in the HAB/AHAB signing flow. The same variables still represent the SRK, CSF, IMG, or SGK certificates as in the filesystem-based setup; only the way they are referenced is different.
 
+For detailed instructions on building secure boot-enabled images for i.MX-based SoCs with HSM-backed keys, see the article [Secure Boot Image Signing for NXP i.MX with HSM-Backed Keys](https://developer.toradex.com/linux-bsp/os-development/security/secure-boot-with-hsm-backed-keys) on the Toradex Developer website.
+
 > **Note:** When HSM-backed signing is enabled for NXP i.MX secure-boot builds, the CST tool is built from source so that PKCS#11 support is available.
+
+### Configuring TI K3 boot container signing
+
+On TI K3 platforms, the boot container is signed during the U-Boot build by U-Boot's `binman` tool using OpenSSL. In the default setup, `binman` reads the SMPK private key from a file on the filesystem. When HSM-backed signing is enabled, `binman` accesses the private key in the HSM through a PKCS#11 provider instead.
+
+Two variables control this:
+
+- `TDX_SIGNED_HSM_K3_BINMAN_KEY_URL` — the PKCS#11 URI of the SMPK private key object, forwarded to `binman` as the `keyfile` entry argument
+- `TDX_SIGNED_HSM_K3_OPENSSL_CONF` — optional path to an OpenSSL configuration file activating the `pkcs11` provider; when empty, one is generated automatically at build time using `TDX_SIGNED_HSM_PKCS11_MODULE_PATH`
+
+A typical configuration looks like:
+
+```
+TDX_SIGNED_HSM_K3_BINMAN_KEY_URL = "pkcs11:token=boot-hsm;object=custMpk;type=private"
+```
+
+If you want to provide your own OpenSSL configuration file instead of relying on the one generated by the build system, point `TDX_SIGNED_HSM_K3_OPENSSL_CONF` at it. The file must activate the `pkcs11` provider and configure it to load the PKCS#11 module corresponding to your HSM. A minimal example:
+
+```
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+pkcs11 = pkcs11_sect
+
+[default_sect]
+activate = 1
+
+[pkcs11_sect]
+pkcs11-module-path = /usr/lib/softhsm/libsofthsm2.so
+pkcs11-module-quirks = no-deinit
+activate = 1
+```
 
 ### Configuring FIT image signing
 
@@ -157,7 +197,7 @@ TDX_SIGNED_HSM_FIT_TOKEN_URL = "model=SoftHSM%20v2;manufacturer=SoftHSM%20projec
 TDX_SIGNED_HSM_FIT_TOKEN_LABEL = "fit-sign-key"
 ```
 
-And the following example shows the configuration using Yubikey for image signing on iMX AHAB based SoMs:
+The following example shows the configuration using Yubikey for image signing on iMX AHAB based SoMs:
 
 ```
 TDX_SIGNED_HSM = "1"
@@ -169,6 +209,34 @@ TDX_IMX_HAB_CST_SRK_CERT = "pkcs11:token=YubiKey%20PIV%20%2322863375;id=%06;type
 TDX_IMX_HAB_CST_SGK_CERT = "pkcs11:token=YubiKey%20PIV%20%2322863375;id=%07;type=cert;pin-value=${TDX_SIGNED_HSM_TOKEN_PIN}"
 
 TDX_SIGNED_HSM_FIT_TOKEN_URL = "model=YubiKey%20YK5;manufacturer=Yubico%20%28www.yubico.com%29;serial=22863375;token=YubiKey%20PIV%20%2322863375;id=%12"
+TDX_SIGNED_HSM_FIT_TOKEN_LABEL = "yk-dev-key"
+```
+
+The following example shows a development setup using SoftHSM for image signing on TI K3 based SoMs:
+
+```
+TDX_SIGNED_HSM = "1"
+
+TDX_SIGNED_HSM_PKCS11_MODULE_PROVIDER = "softhsm-native"
+TDX_SIGNED_HSM_PKCS11_MODULE_PATH = "/usr/lib/softhsm/libsofthsm2.so"
+
+TDX_SIGNED_HSM_K3_BINMAN_KEY_URL = "pkcs11:token=boot-hsm;object=custMpk;type=private"
+
+TDX_SIGNED_HSM_FIT_TOKEN_URL = "model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=984ed1d2002d1c09;token=fit-hsm"
+TDX_SIGNED_HSM_FIT_TOKEN_LABEL = "fit-sign-key"
+```
+
+The following example shows the configuration using YubiKey for image signing on TI K3 based SoMs:
+
+```
+TDX_SIGNED_HSM = "1"
+
+TDX_SIGNED_HSM_PKCS11_MODULE_PROVIDER = "yubico-piv-tool-native"
+TDX_SIGNED_HSM_PKCS11_MODULE_PATH = "/usr/lib/libykcs11.so"
+
+TDX_SIGNED_HSM_K3_BINMAN_KEY_URL = "pkcs11:token=YubiKey%20PIV%20%2322863375;id=%05;type=private"
+
+TDX_SIGNED_HSM_FIT_TOKEN_URL = "token=YubiKey%20PIV%20%2322863375;id=%06"
 TDX_SIGNED_HSM_FIT_TOKEN_LABEL = "yk-dev-key"
 ```
 

--- a/recipes-bsp/u-boot/files/0001-binman-x509_cert-support-PKCS-11-URI-in-keyfile-for-.patch
+++ b/recipes-bsp/u-boot/files/0001-binman-x509_cert-support-PKCS-11-URI-in-keyfile-for-.patch
@@ -1,0 +1,111 @@
+From 9e29dc0590c1015898037bde712a609f68164ff6 Mon Sep 17 00:00:00 2001
+From: Sergio Prado <sergio.prado@e-labworks.com>
+Date: Mon, 25 May 2026 15:32:34 -0300
+Subject: [PATCH] binman: x509_cert: support PKCS#11 URI in keyfile for HSM signing
+
+Allow x509 certificate entries to be signed using a key stored in an
+HSM by accepting a PKCS#11 URI (RFC 7512) as the value of the
+'keyfile' entry argument, instead of a path to a PEM key file on
+disk. The URI is forwarded as-is to openssl '-key', which resolves it
+via the pkcs11 provider configured externally through OPENSSL_CONF. Set
+BINMAN_X509_KEY_URI to override the 'keyfile' entry argument:
+
+  make BINMAN_X509_KEY_URI="pkcs11:token=mytk;object=mykey;type=private" \
+       OPENSSL_CONF=/path/to/openssl.cnf
+
+PKCS11_PIN, when set, is appended to the URI as a percent-encoded
+pin-value=<pin> query parameter (per RFC 7512) so signing runs
+non-interactively. The preferred way to deliver the PIN is via
+pkcs11-module-token-pin in openssl.cnf.
+
+This is the minimal subset of the upstream v5 series sent on
+2026-05-25; documentation, tests, and the test fixture are omitted
+to minimise rebase friction when U-Boot is bumped.
+
+Upstream-Status: Submitted [https://lists.denx.de/pipermail/u-boot/2026-May/619780.html]
+Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>
+---
+ Makefile                        |  1 +
+ tools/binman/etype/x509_cert.py | 19 +++++++++++++++----
+ 2 files changed, 16 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 6558415a8b5a..785331dcbebd 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1359,6 +1359,7 @@ cmd_binman = $(srctree)/tools/binman/binman $(if $(BINMAN_DEBUG),-D) \
+ 		-a spl-dtb=$(CONFIG_SPL_OF_REAL) \
+ 		-a tpl-dtb=$(CONFIG_TPL_OF_REAL) \
+ 		-a pre-load-key-path=${PRE_LOAD_KEY_PATH} \
++		$(if $(BINMAN_X509_KEY_URI),-a keyfile="$(BINMAN_X509_KEY_URI)") \
+ 		$(BINMAN_$(@F))
+ 
+ OBJCOPYFLAGS_u-boot.ldr.hex := -I binary -O ihex
+diff --git a/tools/binman/etype/x509_cert.py b/tools/binman/etype/x509_cert.py
+index 29630d1b86c8..d6a55f82dcc7 100644
+--- a/tools/binman/etype/x509_cert.py
++++ b/tools/binman/etype/x509_cert.py
+@@ -7,6 +7,7 @@
+ 
+ from collections import OrderedDict
+ import os
++import urllib.parse
+ 
+ from binman.entry import EntryArg
+ from binman.etype.collection import Entry_collection
+@@ -79,6 +80,16 @@ class Entry_x509_cert(Entry_collection):
+         if input_data is None:
+             return None
+ 
++        # When keyfile is a PKCS#11 URI and PKCS11_PIN is set, append the
++        # PIN to the URI. A local variable is used rather than mutating
++        # self.key_fname because ProcessContents() calls GetCertificate()
++        # a second time; mutating in place would double-append the PIN.
++        key_fname = self.key_fname
++        pin = os.environ.get('PKCS11_PIN')
++        if pin and 'pkcs11:' in key_fname:
++            sep = '&' if '?' in key_fname else '?'
++            key_fname = f'{key_fname}{sep}pin-value={urllib.parse.quote(pin, safe="")}'
++
+         uniq = self.GetUniqueName()
+         output_fname = tools.get_output_filename('cert.%s' % uniq)
+         input_fname = tools.get_output_filename('input.%s' % uniq)
+@@ -88,7 +99,7 @@ class Entry_x509_cert(Entry_collection):
+             stdout = self.openssl.x509_cert(
+                 cert_fname=output_fname,
+                 input_fname=input_fname,
+-                key_fname=self.key_fname,
++                key_fname=key_fname,
+                 cn=self._cert_ca,
+                 revision=self._cert_rev,
+                 config_fname=config_fname)
+@@ -96,7 +107,7 @@ class Entry_x509_cert(Entry_collection):
+             stdout = self.openssl.x509_cert_sysfw(
+                 cert_fname=output_fname,
+                 input_fname=input_fname,
+-                key_fname=self.key_fname,
++                key_fname=key_fname,
+                 config_fname=config_fname,
+                 sw_rev=self.sw_rev,
+                 req_dist_name_dict=self.req_dist_name,
+@@ -105,7 +116,7 @@ class Entry_x509_cert(Entry_collection):
+             stdout = self.openssl.x509_cert_rom(
+                 cert_fname=output_fname,
+                 input_fname=input_fname,
+-                key_fname=self.key_fname,
++                key_fname=key_fname,
+                 config_fname=config_fname,
+                 sw_rev=self.sw_rev,
+                 req_dist_name_dict=self.req_dist_name,
+@@ -119,7 +130,7 @@ class Entry_x509_cert(Entry_collection):
+             stdout = self.openssl.x509_cert_rom_combined(
+                 cert_fname=output_fname,
+                 input_fname=input_fname,
+-                key_fname=self.key_fname,
++                key_fname=key_fname,
+                 config_fname=config_fname,
+                 sw_rev=self.sw_rev,
+                 req_dist_name_dict=self.req_dist_name,
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/u-boot-k3-secboot-hsm.inc
+++ b/recipes-bsp/u-boot/u-boot-k3-secboot-hsm.inc
@@ -1,0 +1,9 @@
+inherit tdx-signed-hsm-env
+
+SRC_URI += "\
+    file://0001-binman-x509_cert-support-PKCS-11-URI-in-keyfile-for-.patch \
+"
+
+do_compile:prepend() {
+    tdx_signed_hsm_vars_export_k3_binman
+}

--- a/recipes-bsp/u-boot/u-boot-k3-secboot.inc
+++ b/recipes-bsp/u-boot/u-boot-k3-secboot.inc
@@ -1,9 +1,17 @@
 update_signing_keys() {
-    echo "Updating signing keys directory '${S}/arch/arm/mach-k3/keys'"
-    rm -Rf "${S}/arch/arm/mach-k3/keys"
-    cp -rv "${TDX_K3_SECBOOT_KEY_DIR}" "${S}/arch/arm/mach-k3/keys"
+    if [ "${TDX_SIGNED_HSM}" = "1" ]; then
+        echo "HSM-backed signing: skipping copy of on-disk signing keys"
+        return 0
+    else
+        echo "Updating signing keys directory '${S}/arch/arm/mach-k3/keys'"
+        rm -Rf "${S}/arch/arm/mach-k3/keys"
+        cp -rv "${TDX_K3_SECBOOT_KEY_DIR}" "${S}/arch/arm/mach-k3/keys"
+    fi
 }
 
 do_unpack:append() {
     bb.build.exec_func('update_signing_keys', d)
 }
+
+# enable HSM-backed signing for the K3 boot container
+require ${@oe.utils.conditional('TDX_SIGNED_HSM', '1', 'u-boot-k3-secboot-hsm.inc', '', d)}

--- a/recipes-support/pkcs11-provider/pkcs11-provider_%.bbappend
+++ b/recipes-support/pkcs11-provider/pkcs11-provider_%.bbappend
@@ -1,0 +1,4 @@
+# pkcs11-provider-native is used by recipes in this layer to sign artifacts
+# via PKCS#11 (e.g. binman signing the TI K3 boot container with an HSM-backed
+# key). The upstream recipe does not declare a native variant, so enable it here.
+BBCLASSEXTEND += "native"


### PR DESCRIPTION
This PR extends HSM-backed signing to support the TI K3 boot container, completing HSM coverage across the secure boot signing chain for TI K3 targets.

On TI K3, the boot container is signed during the U-Boot build by U-Boot's `binman` tool through OpenSSL-driven `x509_cert` entries. To allow a PKCS#11 URI to be used in place of an on-disk key file, this PR adds a downstream patch to binman's `x509_cert` entry type. The patch is a minimal subset of the upstream v5 series in [1].

The implementation was build and runtime-tested on AM62 with both SoftHSM and YubiKey. It was also build and runtime-tested on i.MX8MM to verify that no regressions were introduced.

[1] https://patchwork.ozlabs.org/project/uboot/patch/20260525132828.3348679-3-sergio.prado@e-labworks.com/