### PR TITLE
u-boot: allow generating bootloader suitable for SDP loading (iMX6ULL/iMX7)

### DIFF
--- a/classes/imx-hab.bbclass
+++ b/classes/imx-hab.bbclass
@@ -142,3 +142,12 @@ TDX_IMX_HAB_CST_SGK_SUPP  ?= "1"
 
 # Only SRK is supported in the current released firmware (April 2025) for iMX9 based SoCs
 TDX_IMX_HAB_CST_SGK_SUPP:mx9-generic-bsp ?= "0"
+
+# List of U-Boot configurations targeting SDP loading; "*" means all;
+# normally this would be a subset of the values in UBOOT_CONFIG
+TDX_IMX_HAB_SDP_CONFIGS ?= ""
+
+# Internal version of the above variable making it relevant on specific SoCs
+TDX_IMX_HAB_SDP_CONFIGS_INTERNAL ?= ""
+TDX_IMX_HAB_SDP_CONFIGS_INTERNAL:mx6ull-generic-bsp = "${TDX_IMX_HAB_SDP_CONFIGS}"
+TDX_IMX_HAB_SDP_CONFIGS_INTERNAL:mx7-generic-bsp = "${TDX_IMX_HAB_SDP_CONFIGS}"

--- a/docs/README-secure-boot-imx.md
+++ b/docs/README-secure-boot-imx.md
@@ -36,18 +36,39 @@ After that, configure the various variables listed below to match your choices; 
 | `TDX_IMX_HAB_CST_DIG_ALGO` | Digest algorithm as entered into the CST tool. | `sha256` |
 | `TDX_IMX_HAB_CST_SRK_CA` | Whether or not the SRK certificates have the CA flag set as entered into the CST tool; allowed values: `0` or `1`. | `1` |
 | `TDX_IMX_HAB_CST_SRK_INDEX` | Index of the SRK to be used for signing within the SRK table; allowed values: `1`..`4`, corresponding to `SRK1`..`SRK4`, respectively. | `1` |
+| `TDX_IMX_HAB_SDP_CONFIGS` | List of U-Boot configurations targeting SDP loading; `*` means all (relevant mainly to the iMX6ULL and iMX7) | Empty |
 | `TDX_IMX_HAB_GEN_UBOOT_FUSING_CMD` | Add a function called `prog_secure_boot_fuses` to U-Boot's environment to program the secure boot fuses. Since this is intended mostly for development/tests, the function will only program the fuses but not close the device. If you enable it and run the function inside U-Boot, be aware that it will write to One-Time Programmable e-fuses, and the operation is irreversible! Allowed values are: `0` (disabled) or `1` (enabled). | `0` |
 
 The complete list of variables can be found in the `imx-hab.bbclass` file.
 
 **NOTE**: For HAB signing, [libfaketime](https://github.com/wolfcw/libfaketime) is used when generating the CSF binaries with CST in order to create reproducible bootloader image builds.
 
-### Known issues
+### Bootloaders targeting SDP loading
+
+This section is currently relevant to the iMX6ULL and iMX7 SoCs where a bootloader aiming SDP loading requires a special signing procedure.
+
+The variable `TDX_IMX_HAB_SDP_CONFIGS` can be configured to generate a bootloader suitable for SDP loading and execution.
+
+For builds where multiple U-Boot configurations are specified (e.g., `UBOOT_CONFIG = "config1 config2 config3"`), setting `TDX_IMX_HAB_SDP_CONFIGS = "*"` ensures that all configurations are built with the required modifications for SDP usage.
+
+Normally though, only specific configurations target SDP loading. For example, with `UBOOT_CONFIG = "nand emmc recovery"`, users can set `TDX_IMX_HAB_SDP_CONFIGS = "recovery"` to limit SDP preparation to the `recovery` build.
+
+If `UBOOT_CONFIG` is not being used to set up multiple U-Boot configurations and the only (unnamed) configuration being built is aimed at SDP usage, then users should set `TDX_IMX_HAB_SDP_CONFIGS = "*"`.
+
+In addition to properly setting up the bootloader signing for SDP, users must provide extra parameters to the SDP `boot` command in UUU when loading the generated binary. Specifically, the options `-cleardcd` and `-dcdaddr` are typically required to ensure proper booting without HAB events. For example:
+
+```
+SDP: boot -f u-boot.imx -dcdaddr 0x00910000 -cleardcd
+```
+
+The DCD address can be determined from the `mkimage` output logs produced by U-Boot.
+
+## Known issues
 
 - Starting from version 4.0.0, the NXP CST tool may not work as expected on older Linux distributions (e.g., Ubuntu 20.04). If you are using NXP CST 4.0.0 or later, it is recommended to use a more recent Linux distribution (e.g., Ubuntu 24.04) to ensure compatibility and avoid potential issues.
 - As of April 2025, SGK is not supported in the current firmware for SoCs using the EdgeLock Secure Enclave (ELE), which includes iMX8ULP and iMX9x. Consequently, when building for machines based on these SoCs, the use of subordinate signing keys (SGK) will be disabled, and the boot container will be signed directly with the Super Root Keys (SRK).
 
-### Closing the device
+## Closing the device
 
 If HAB/AHAB is enabled, at the end of the build, a file with the commands to fuse the SoC (`fuse-cmds.txt`) will be generated in the images directory. The commands in this file should be executed in the U-Boot command line interface.
 

--- a/recipes-bsp/u-boot/files/imx6_imx7_create_csf.sh
+++ b/recipes-bsp/u-boot/files/imx6_imx7_create_csf.sh
@@ -13,6 +13,7 @@ MACHINE=""
 CSF=""
 TEMPLATE_FILE=""
 LIBFAKETIME_PATH="${LIBFAKETIME_PATH}"
+CSF_INC_DCD="${CSF_INC_DCD:-0}"
 
 # Timestamp to be used by libfaketime. The date itself isn't important, but this needs
 # to be constant between builds in order to generate deterministic CSF binaries
@@ -50,6 +51,9 @@ help() {
     echo " Optional Environment Variables:"
     echo
     echo "    TDX_IMX_HAB_CST_ARGS      Additional parameters to be passed to the CST tool"
+    echo "    CSF_INC_DCD               Include the DCD Blocks in the Authenticate Data areas of the CSF"
+    echo "                              Set to 1 when generating bootloaders aimed at SDP usage (iMX6ULL/7)"
+    echo "                              default: 0"
     echo "    LIBFAKETIME_PATH          Path to libfaketime library (needed for reproducible CSF binary builds)"
     echo "                              default: unset"
     echo
@@ -214,8 +218,21 @@ generate_csf() {
     # Delete 'Blocks =' section from template
     sed -i "/Blocks = /d" "${image_csf}"
 
-    # Append Blocks
-    echo "    Blocks = $(grep 'HAB Blocks' "${HAB_LOG}" | awk '{print $3, $4, $5}') \"${IMXBOOT}\"" >> "${image_csf}"
+    if grep -q "HAB Blocks" "${HAB_LOG}"; then
+        echo "    Blocks = $(grep 'HAB Blocks' "${HAB_LOG}" | awk '{print $3, $4, $5}') \"${IMXBOOT}\"" >> "${image_csf}"
+    else
+        error "Could not find 'HAB Blocks' section in '${HAB_LOG}'; aborting."
+    fi
+
+    if [ "${CSF_INC_DCD}" = "1" ]; then
+        if grep -q "DCD Blocks" "${HAB_LOG}"; then
+            # Add comma to last line and append extra line with DCD blocks.
+            sed -e '$ s/$/, \\/' -i "${image_csf}"
+            echo "             $(grep 'DCD Blocks' "${HAB_LOG}" | awk '{print $3, $4, $5}') \"${IMXBOOT}\"" >> "${image_csf}"
+        else
+            error "Could not find 'DCD Blocks' section in '${HAB_LOG}'; aborting."
+        fi
+    fi
 
     # Generate Binary
     if ! env ${LIBFAKETIME_PATH+LD_PRELOAD="${LIBFAKETIME_PATH}"

--- a/recipes-bsp/u-boot/u-boot-fit-signature-nxp.inc
+++ b/recipes-bsp/u-boot/u-boot-fit-signature-nxp.inc
@@ -1,6 +1,8 @@
 concat_dtb_pre_common() {
-    if [ "${UBOOT_MAKE_TARGET}" != "u-boot.imx" ]; then
-        bbfatal "Don't know how to handle a make target other than u-boot.imx"
+    # $1: type
+    # $2: binary
+    if [ "$2" != "u-boot.imx" ]; then
+        bbfatal "Don't know how to handle a bootloader binary ($2) other than u-boot.imx"
     fi
 
     # When the make target is "u-boot.imx" the u-boot.dtb file is not generated;
@@ -11,15 +13,17 @@ concat_dtb_pre_common() {
 }
 
 concat_dtb_post_common() {
-    if [ "${UBOOT_MAKE_TARGET}" != "u-boot.imx" ]; then
-        bbfatal "Don't know how to handle a make target other than u-boot.imx"
+    # $1: type
+    # $2: binary
+    if [ "$2" != "u-boot.imx" ]; then
+        bbfatal "Don't know how to handle a bootloader binary ($2) other than u-boot.imx"
     fi
 
     # Since concat_dtb() doesn't know how to handle a u-boot.imx file it will
     # wrongly generate it by simply concatenating it with the u-boot.dtb binary;
     # fix this by regenerating u-boot.imx now with the signed u-boot-dtb.
-    rm -f "${UBOOT_MAKE_TARGET}"
-    oe_runmake EXT_DTB="${UBOOT_DTB_SIGNED}" ${UBOOT_MAKE_TARGET}
+    rm -f "u-boot.imx"
+    oe_runmake EXT_DTB="${UBOOT_DTB_SIGNED}" "u-boot.imx"
 }
 
 concat_dtb:prepend:mx6ull-generic-bsp() {
@@ -54,7 +58,7 @@ concat_dtb:append:mx8m-generic-bsp() {
 
     # Execute make again to generate flash.bin. We could execute "make" passing
     # EXT_DTB="${UBOOT_DTB_SIGNED}" but this wouldn't help (or hurt) because the
-    # extra signature node presente in the signed DTB is not used by binman;
+    # extra signature node present in the signed DTB is not used by binman;
     # binman uses the DTs listed in CONFIG_OF_LIST directly and that's why we
     # updated them in the previous steps.
     oe_runmake ${UBOOT_MAKE_TARGET}

--- a/recipes-bsp/u-boot/u-boot-hab.inc
+++ b/recipes-bsp/u-boot/u-boot-hab.inc
@@ -41,6 +41,30 @@ UBOOT_BINARY_HAB = "${UBOOT_BINARY}"
 UBOOT_BINARY_HAB:mx6dl-generic-bsp = "u-boot-ivt.img"
 UBOOT_BINARY_HAB:mx6q-generic-bsp = "u-boot-ivt.img"
 
+python __anonymous() {
+    scfgs = (d.getVar('TDX_IMX_HAB_SDP_CONFIGS_INTERNAL') or "").split()
+    ucfgs = (d.getVar('UBOOT_CONFIG') or "").split()
+    if not ucfgs:
+        for _scfg in scfgs:
+            if _scfg != "*":
+                bb.warnonce(
+                    'UBOOT_CONFIG is not in use; TDX_IMX_HAB_SDP_CONFIGS should '
+                    'be either empty or set to "*", but it instead contains a '
+                    f'configuration named "{_scfg}"; bootloader will not be '
+                    'built for SDP loading.')
+                break
+        return
+
+    for _scfg in scfgs:
+        if _scfg == "*":
+            continue
+        if _scfg not in ucfgs:
+            bb.warnonce(
+                f'Configuration named "{_scfg}" in TDX_IMX_HAB_SDP_CONFIGS '
+                'is not listed in UBOOT_CONFIG and will be ignored; your '
+                'bootloader may not be built for SDP loading.')
+}
+
 # Sign U-Boot binary and/or SPL (this works both with i.MX6 and i.MX7).
 # This is supposed to run in the U-Boot build directory.
 imx6_imx7_sign_habv4() {
@@ -52,7 +76,43 @@ imx6_imx7_sign_habv4() {
         bbfatal "Could not find CST binary at ${TDX_IMX_HAB_CST_BIN}."
     fi
 
-    bbdebug 1 "Generating CSF for U-Boot"
+    binary_to_sign="${UBOOT_BINARY_HAB}"
+    binary_to_mkcsf="${UBOOT_BINARY_HAB}"
+
+    csf_inc_dcd="0"
+    # Run loop in a subshell with set -f to avoid expansion of "*", which
+    # variable TDX_IMX_HAB_SDP_CONFIGS (and the internal one) may contain.
+    (
+	set -f
+	for _config in ${TDX_IMX_HAB_SDP_CONFIGS_INTERNAL}; do
+            if [ "${_config}" = "${type}" ] || [ "${_config}" = "*" ]; then
+		exit 0
+            fi
+	done
+	exit 1
+    ) && csf_inc_dcd="1"
+
+    # For SDP loading we need:
+    #
+    # (a) a CSF determined from a bootloader with a cleared DCD pointer; and
+    # (b) a CSF that covers (protects) the DCD blocks.
+    #
+    if [ "${csf_inc_dcd}" = "1" ]; then
+        bbdebug 1 "Generating bootloader binary with cleared DCD pointer (type='${type}')"
+        if [ "$(xxd -p -l1 "${binary_to_sign}")" != "d1" ]; then
+            bbfatal "File '${binary_to_sign}' does not seem to start with an IVT; aborting."
+        fi
+        binary_to_mkcsf="${UBOOT_BINARY_HAB}-clrdcd"
+        cp -v "${binary_to_sign}" "${binary_to_mkcsf}"
+        cp -v "${binary_to_sign}.log" "${binary_to_mkcsf}.log"
+        # As per IMX6DRM/IMX7DRM, section titled "Image vector table structure",
+        # the 32-bit DCD pointer is at offset 12 (0xC); clear it.
+        printf '\0\0\0\0' | dd of="${binary_to_mkcsf}" bs=1 seek=12 conv=notrunc
+    else
+        bbdebug 1 "DCD pointer clearing has been skipped"
+    fi
+
+    bbdebug 1 "Generating CSF from U-Boot binary '${binary_to_mkcsf}' (type='${type}')"
     # Generate CSF file:
     LIBFAKETIME_PATH="${STAGING_LIBDIR_NATIVE}/faketime/libfaketime.so.1" \
     TDX_IMX_HAB_CST_SRK="${TDX_IMX_HAB_CST_SRK}" \
@@ -61,17 +121,18 @@ imx6_imx7_sign_habv4() {
     TDX_IMX_HAB_CST_IMG_CERT="${TDX_IMX_HAB_CST_IMG_CERT}" \
     TDX_IMX_HAB_CST_BIN="${TDX_IMX_HAB_CST_BIN}" \
     TDX_IMX_HAB_CST_ARGS="${TDX_IMX_HAB_CST_ARGS}" \
-    IMXBOOT="${UBOOT_BINARY_HAB}" \
-    HAB_LOG="${UBOOT_BINARY_HAB}.log" \
+    CSF_INC_DCD="${csf_inc_dcd}" \
+    IMXBOOT="${binary_to_mkcsf}" \
+    HAB_LOG="${binary_to_mkcsf}.log" \
     ${WORKDIR}/imx6_imx7_create_csf.sh -m "${soc}" -c "csf_uboot"
 
     # Save unsigned image and generate signed version by concatenating with the CSF.
-    bbdebug 1 "Concatenating CSF binary to U-Boot"
+    bbdebug 1 "Concatenating CSF binary to U-Boot binary '${binary_to_sign}'"
     if [ -n "${type}" ]; then
-        cp  "${UBOOT_BINARY_HAB}" "${UBOOT_BINARYNAME}-${type}.${UBOOT_SUFFIX}-unsigned"
-        cat "${UBOOT_BINARY_HAB}" "csf_uboot.bin" > "${UBOOT_BINARYNAME}-${type}.${UBOOT_SUFFIX}"
+        cp  "${binary_to_sign}" "${UBOOT_BINARYNAME}-${type}.${UBOOT_SUFFIX}-unsigned"
+        cat "${binary_to_sign}" "csf_uboot.bin" > "${UBOOT_BINARYNAME}-${type}.${UBOOT_SUFFIX}"
     else
-        mv  "${UBOOT_BINARY_HAB}" "${UBOOT_BINARY}-unsigned"
+        mv  "${binary_to_sign}" "${UBOOT_BINARY}-unsigned"
         cat "${UBOOT_BINARY}-unsigned" "csf_uboot.bin" > "${UBOOT_BINARY}"
     fi
 

--- a/recipes-bsp/u-boot/u-boot-harden.inc
+++ b/recipes-bsp/u-boot/u-boot-harden.inc
@@ -231,10 +231,22 @@ SRC_URI:append = "\
 "
 
 CP_PROT_SUPPORTED ?= "0"
+CP_PROT_SUPPORTED:apalis-imx6 ?= "1"
+CP_PROT_SUPPORTED:colibri-imx6 ?= "1"
+CP_PROT_SUPPORTED:colibri-imx6ull ?= "1"
+CP_PROT_SUPPORTED:colibri-imx6ull-emmc ?= "1"
+CP_PROT_SUPPORTED:colibri-imx7 ?= "1"
+CP_PROT_SUPPORTED:colibri-imx7-emmc ?= "1"
 CP_PROT_SUPPORTED:verdin-imx8mm ?= "1"
 CP_PROT_SUPPORTED:verdin-imx8mp ?= "1"
 
 FB_PROT_SUPPORTED ?= "0"
+FB_PROT_SUPPORTED:apalis-imx6 ?= "1"
+FB_PROT_SUPPORTED:colibri-imx6 ?= "1"
+FB_PROT_SUPPORTED:colibri-imx6ull ?= "1"
+FB_PROT_SUPPORTED:colibri-imx6ull-emmc ?= "1"
+FB_PROT_SUPPORTED:colibri-imx7 ?= "1"
+FB_PROT_SUPPORTED:colibri-imx7-emmc ?= "1"
 FB_PROT_SUPPORTED:verdin-imx8mm ?= "1"
 FB_PROT_SUPPORTED:verdin-imx8mp ?= "1"
 


### PR DESCRIPTION
Allow generating a bootloader binary suitable for SDP loading, getting rid of the HAB events that happened before on the iMX6ULL and iMX7.

Also, consider the memory copy (CP) and Fastboot (FB) protections to be "implemented" on machines based on those SoCs, now that they have been runtime tested with a build of TEZI.

Build tests have been performed with Torizon OS and TDXREF images to ensure the build still succeeds (runtime tests are left for the test system).

Related-to: TOR-4400, TOR-4431, TOR-4432
Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
