### PR TITLE
docs: document i.MX 8M TZASC region 0 secure memory limitation

### DIFF
--- a/docs/README-optee.md
+++ b/docs/README-optee.md
@@ -167,7 +167,17 @@ For additional details on how the PKCS#11 Trusted Application works, refer to th
 
 ## Limitations
 
+### Colibri iMX6
+
 Currently, OP-TEE cannot be used in conjunction with HAB on Colibri iMX6 due to a limitation in the signing process. A different U-Boot image is generated when OP-TEE is enabled, and the signing scripts need to be adapted to handle it.
+
+### i.MX 8M
+
+On i.MX 8M, OP-TEE secure memory is currently not fully isolated from the normal world. Because the i.MX 8M DDR controller ignores the upper address bits, secure DRAM can also be reached through address aliases that fall through to the TZASC background region 0, which the boot firmware (U-Boot and TF-A) leaves open to the normal world. As a result, a compromised Linux kernel could read OP-TEE secrets such as cryptographic keys or fTPM state.
+
+Exploiting this requires kernel-level code execution, so the practical risk is reduced when secure boot is enabled: a signed boot chain prevents the kernel from being replaced and kernel module signing prevents loading malicious modules, both of which make obtaining kernel-level access harder (though a runtime kernel exploit would still bypass them). Kernel hardening such as `CONFIG_STRICT_DEVMEM` and the device tree `nomap` reservations also limit access to physical memory against user space code.
+
+Fully closing this gap requires coordinated changes in OP-TEE, TF-A and U-Boot (via the the upstream `CFG_TZASC_REGION0_SECURE` option, available in OP-TEE 4.10.0 and newer) and is expected to be resolved once the NXP BSP adopts a newer OP-TEE.
 
 ## Important note
 


### PR DESCRIPTION
Add a note to the OP-TEE limitations section describing that, on i.MX 8M, OP-TEE secure memory is not fully isolated from the normal world. The DDR controller ignores the upper address bits, so secure DRAM can be reached through address aliases that fall through to the TZASC background region 0, which the boot firmware leaves open to the normal world. A compromised kernel could therefore read OP-TEE secrets such as keys or fTPM state.

Document this so users running OP-TEE or secure boot on i.MX 8M can make an informed risk decision while a fix is pending. The note also explains the practical mitigations and their limits: secure boot and kernel module signing reduce the likelihood of kernel-level compromise (the prerequisite for exploitation), while CONFIG_STRICT_DEVMEM and the device tree nomap reservations mainly guard against user space code. Fully closing the gap requires coordinated OP-TEE, TF-A and U-Boot changes and is expected once the BSP adopts a newer OP-TEE.

See https://sigma-star.at/blog/2026/06/trustzone-intermezzo/ for more information on the bug.