### PR TITLE
master: fix build for master branch

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -21,7 +21,7 @@ LAYERSERIES_COMPAT_meta-toradex-security = "wrynose"
 
 BBFILES_DYNAMIC += " \
     freescale-layer:${LAYERDIR}/dynamic-layers/freescale/*/*/*.bbappend \
-    toradex-ti-layer:${LAYERDIR}/dynamic-layers/toradex-ti/*/*/*.bbappend \
-    toradex-nxp-layer:${LAYERDIR}/dynamic-layers/toradex-nxp/*/*/*.bbappend \
-    toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/toradex-bsp-common/*/*/*.bbappend \
+    toradex-ti-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp/toradex-ti/*/*/*.bbappend \
+    toradex-nxp-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp/toradex-nxp/*/*/*.bbappend \
+    toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp/toradex-bsp-common/*/*/*.bbappend \
 "

--- a/dynamic-layers/toradex-ti/recipes-bsp/u-boot/u-boot-toradex-ti_%.bbappend
+++ b/dynamic-layers/toradex-ti/recipes-bsp/u-boot/u-boot-toradex-ti_%.bbappend
@@ -1,1 +1,0 @@
-require ${@ 'recipes-bsp/u-boot/u-boot-secure-boot.inc' if 'tdx-signed' in d.getVar('OVERRIDES').split(':') else ''}


### PR DESCRIPTION
meta-toradex-ti, meta-toradex-nxp and meta-toradex-bsp-common were merged into the single meta-toradex-bsp repo as subdirectories. Update BBFILES_DYNAMIC to match the new physical layout, and remove the u-boot-toradex-ti bbappend left behind at the old, now-unused dynamic-layers/toradex-ti path.