### PR TITLE
Report HAB/AHAB events through the hab_status/ahab_status exit code

### DIFF
--- a/docs/README-secure-boot-imx.md
+++ b/docs/README-secure-boot-imx.md
@@ -72,7 +72,11 @@ The DCD address can be determined from the `mkimage` output logs produced by U-B
 
 If HAB/AHAB is enabled, at the end of the build, a file with the commands to fuse the SoC (`fuse-cmds.txt`) will be generated in the images directory. The commands in this file should be executed in the U-Boot command line interface.
 
-Read the warning messages carefully and be aware that the commands will write to One-Time Programmable e-fuses, and once you write them, you can't go back! You can check for HAB events with the command `hab_status` for HAB or `ahab_status` for AHAB. It is recommended to read NXP documentation about HAB/AHAB before writing to the e-fuses. This is an output example of the `fuse-cmds.txt` file:
+Read the warning messages carefully and be aware that the commands will write to One-Time Programmable e-fuses, and once you write them, you can't go back! You can check for HAB events with the command `hab_status` for HAB or `ahab_status` for AHAB. It is recommended to read NXP documentation about HAB/AHAB before writing to the e-fuses.
+
+By default these commands always report success, even when events are found. To make it possible to check the result from a boot script, this layer patches U-Boot so that both commands return a non-zero exit code whenever an event is reported. The only exception is a well-known RNG self-test event on i.MX6 SoCs, which is ignored and does not make the command fail.
+
+This is an output example of the `fuse-cmds.txt` file:
 
 ```
 $ cat deploy/images/verdin-imx8mp/fuse-cmds.txt

--- a/recipes-bsp/u-boot/files/u-boot-hab-status/0001-toradex-adjust-ahab_status-exit-code-behavior-ele.patch
+++ b/recipes-bsp/u-boot/files/u-boot-hab-status/0001-toradex-adjust-ahab_status-exit-code-behavior-ele.patch
@@ -1,0 +1,37 @@
+From 912c0b5e962ccc595957cf9a1b9224ac9dce8e7c Mon Sep 17 00:00:00 2001
+From: Sergio Prado <sergio.prado@e-labworks.com>
+Date: Thu, 30 Jul 2026 13:26:25 -0300
+Subject: [PATCH] toradex: adjust ahab_status exit code behavior on ELE based
+ SoCs
+
+Adjust exit code behavior to return an error if any ELE event is found,
+so that the result of the command can be checked from a boot script.
+
+SoCs using the EdgeLock Enclave (e.g. i.MX9x) implement the ahab_status
+command in ele_ahab.c, which reported the events found but always
+returned success. This is the ELE counterpart of the same change
+already done for the SECO based implementation used by i.MX8.
+
+Upstream-Status: Inappropriate [Toradex specific]
+
+Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>
+---
+ arch/arm/mach-imx/ele_ahab.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/mach-imx/ele_ahab.c b/arch/arm/mach-imx/ele_ahab.c
+index acefc62b5266..d8e532592c02 100644
+--- a/arch/arm/mach-imx/ele_ahab.c
++++ b/arch/arm/mach-imx/ele_ahab.c
+@@ -649,7 +649,7 @@ static int do_ahab_status(struct cmd_tbl *cmdtp, int flag, int argc, char *const
+ 	for (i = 0; i < cnt; i++)
+ 		display_event(events[i]);
+ 
+-	return 0;
++	return CMD_RET_FAILURE;
+ }
+ 
+ static int do_sec_fuse_prog(struct cmd_tbl *cmdtp, int flag, int argc, char *const argv[])
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/u-boot-hab-status/0001-toradex-adjust-ahab_status-exit-code-behavior-seco.patch
+++ b/recipes-bsp/u-boot/files/u-boot-hab-status/0001-toradex-adjust-ahab_status-exit-code-behavior-seco.patch
@@ -1,0 +1,47 @@
+From 2e6f06e945971661d9d9bd3edc01317132041eba Mon Sep 17 00:00:00 2001
+From: Jeremias Cordoba <js.cordoba8321@gmail.com>
+Date: Wed, 20 Nov 2024 16:16:24 -0800
+Subject: [PATCH] toradex: adjust ahab_status exit code behavior on SECO
+ based SoCs
+
+Adjust exit code behavior to return a 1 if there are any
+SECO events.
+
+Upstream-Status: Inappropriate [Toradex specific]
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>
+---
+ arch/arm/mach-imx/imx8/ahab.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/mach-imx/imx8/ahab.c b/arch/arm/mach-imx/imx8/ahab.c
+index eb3916a7229..800b6d5b554 100644
+--- a/arch/arm/mach-imx/imx8/ahab.c
++++ b/arch/arm/mach-imx/imx8/ahab.c
+@@ -318,6 +318,7 @@ static int do_ahab_status(struct cmd_tbl *cmdtp, int flag, int argc,
+ 	u8 idx = 0U;
+ 	u32 event;
+ 	u16 lc;
++	int retval = 1;
+ 
+ 	err = sc_seco_chip_info(-1, &lc, NULL, NULL, NULL);
+ 	if (err) {
+@@ -336,10 +337,12 @@ static int do_ahab_status(struct cmd_tbl *cmdtp, int flag, int argc,
+ 		err = sc_seco_get_event(-1, idx, &event);
+ 	}
+ 
+-	if (idx == 0)
++	if (idx == 0) {
+ 		printf("No SECO Events Found!\n\n");
++		retval = 0;
++	}
+ 
+-	return 0;
++	return retval;
+ }
+ 
+ int ahab_close(void)
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/u-boot-hab-status/0001-toradex-adjust-hab_status-exit-code-behavior.patch
+++ b/recipes-bsp/u-boot/files/u-boot-hab-status/0001-toradex-adjust-hab_status-exit-code-behavior.patch
@@ -1,0 +1,84 @@
+From c62247cebe58f7a1d48b85355cec6ed13e3d932b Mon Sep 17 00:00:00 2001
+From: Jeremias Cordoba <js.cordoba8321@gmail.com>
+Date: Thu, 5 Dec 2024 15:09:24 -0800
+Subject: [PATCH] toradex: adjust hab_status exit code behavior
+
+Adjust exit code behavior to return a 1 if there are any HAB events.
+An exception is made for a known HAB event on i.MX6 SoCs.
+
+Upstream-Status: Inappropriate [Toradex specific]
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>
+---
+ arch/arm/mach-imx/hab.c | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/mach-imx/hab.c b/arch/arm/mach-imx/hab.c
+index 27e053ef701..91ff7c9dfe6 100644
+--- a/arch/arm/mach-imx/hab.c
++++ b/arch/arm/mach-imx/hab.c
+@@ -18,6 +18,8 @@
+ #include <asm/mach-imx/hab.h>
+ #include <linux/arm-smccc.h>
+ 
++#include <tdx-hab-utils.h>
++
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ #define ALIGN_SIZE		0x1000
+@@ -454,6 +456,7 @@ static int get_hab_status(void)
+ 	size_t bytes = sizeof(event_data); /* Event size in bytes */
+ 	enum hab_config config = 0;
+ 	enum hab_state state = 0;
++	int retval = 0;
+ 
+ 	if (imx_hab_is_enabled())
+ 		puts("\nSecure boot enabled\n");
+@@ -476,6 +479,13 @@ static int get_hab_status(void)
+ 			puts("\n");
+ 			bytes = sizeof(event_data);
+ 			index++;
++#ifdef IGNORE_KNOWN_HAB_EVENTS
++			if (!is_known_fail_event(event_data, bytes)) {
++				retval = 1;
++			}
++#else
++			retval = 1;
++#endif
+ 		}
+ 	}
+ 	/* Display message if no HAB events are found */
+@@ -484,7 +494,7 @@ static int get_hab_status(void)
+ 		       config, state);
+ 		puts("No HAB Events Found!\n\n");
+ 	}
+-	return 0;
++	return retval;
+ }
+ 
+ #ifdef CONFIG_MX7ULP
+@@ -562,6 +572,7 @@ static int get_hab_status_m4(void)
+ static int do_hab_status(struct cmd_tbl *cmdtp, int flag, int argc,
+ 			 char *const argv[])
+ {
++	int retval = 0;
+ #ifdef CONFIG_MX7ULP
+ 	if ((argc > 2)) {
+ 		cmd_usage(cmdtp);
+@@ -578,10 +589,10 @@ static int do_hab_status(struct cmd_tbl *cmdtp, int flag, int argc,
+ 		return 1;
+ 	}
+ 
+-	get_hab_status();
++	retval = get_hab_status();
+ #endif
+ 
+-	return 0;
++	return retval;
+ }
+ 
+ static ulong get_image_ivt_offset(ulong img_addr)
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/files/u-boot-hab-status/0001-toradex-common-add-hab-utilities-module.patch
+++ b/recipes-bsp/u-boot/files/u-boot-hab-status/0001-toradex-common-add-hab-utilities-module.patch
@@ -1,0 +1,94 @@
+From d04025b710b62b78831b223cbff5acfbc24d6e13 Mon Sep 17 00:00:00 2001
+From: Jeremias Cordoba <js.cordoba8321@gmail.com>
+Date: Thu, 5 Dec 2024 15:07:03 -0800
+Subject: [PATCH] toradex: common: add hab utilities module
+
+Add hab utilities module initially containing an auxiliary function to
+detect a known HAB event on i.MX6.
+
+Upstream-Status: Inappropriate [Toradex specific]
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>
+---
+ common/Makefile         |  3 +++
+ common/tdx-hab-utils.c  | 31 +++++++++++++++++++++++++++++++
+ include/tdx-hab-utils.h | 13 +++++++++++++
+ 3 files changed, 47 insertions(+)
+ create mode 100644 common/tdx-hab-utils.c
+ create mode 100644 include/tdx-hab-utils.h
+
+diff --git a/common/Makefile b/common/Makefile
+index e9835473420..15f38f902b0 100644
+--- a/common/Makefile
++++ b/common/Makefile
+@@ -30,6 +30,9 @@ obj-$(CONFIG_USB_GADGET) += usb.o
+ obj-$(CONFIG_USB_STORAGE) += usb_storage.o
+ obj-$(CONFIG_USB_ONBOARD_HUB) += usb_onboard_hub.o
+ 
++obj-$(CONFIG_IMX_HAB) += tdx-hab-utils.o
++obj-$(CONFIG_AHAB_BOOT) += tdx-hab-utils.o
++
+ # others
+ obj-$(CONFIG_CONSOLE_MUX) += iomux.o
+ obj-$(CONFIG_MTD_NOR_FLASH) += flash.o
+diff --git a/common/tdx-hab-utils.c b/common/tdx-hab-utils.c
+new file mode 100644
+index 00000000000..840a640fc58
+--- /dev/null
++++ b/common/tdx-hab-utils.c
+@@ -0,0 +1,31 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright 2024 Toradex
++ */
++
++#include <common.h>
++#include <tdx-hab-utils.h>
++
++#ifdef IGNORE_KNOWN_HAB_EVENTS
++static uint8_t known_rng_fail_event[][RNG_FAIL_EVENT_SIZE] = {
++	{ 0xdb, 0x00, 0x24, 0x42,  0x69, 0x30, 0xe1, 0x1d,
++	  0x00, 0x04, 0x00, 0x02,  0x40, 0x00, 0x36, 0x06,
++	  0x55, 0x55, 0x00, 0x03,  0x00, 0x00, 0x00, 0x00,
++	  0x00, 0x00, 0x00, 0x00,  0x00, 0x00, 0x00, 0x00,
++	  0x00, 0x00, 0x00, 0x01 },
++};
++
++bool is_known_fail_event(const uint8_t *data, size_t len)
++{
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(known_rng_fail_event); i++) {
++		if (memcmp(data, known_rng_fail_event[i],
++			   min_t(size_t, len, RNG_FAIL_EVENT_SIZE)) == 0) {
++			return true;
++		}
++	}
++
++	return false;
++}
++#endif
+diff --git a/include/tdx-hab-utils.h b/include/tdx-hab-utils.h
+new file mode 100644
+index 00000000000..316a0a61c38
+--- /dev/null
++++ b/include/tdx-hab-utils.h
+@@ -0,0 +1,13 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright 2024 Toradex
++ */
++
++#if (defined(CONFIG_MX6Q) || defined(CONFIG_MX6DL) || defined(CONFIG_MX6QDL))
++#define IGNORE_KNOWN_HAB_EVENTS 1
++#endif
++
++#ifdef IGNORE_KNOWN_HAB_EVENTS
++#define RNG_FAIL_EVENT_SIZE 36
++bool is_known_fail_event(const uint8_t *data, size_t len);
++#endif
+-- 
+2.34.1
+

--- a/recipes-bsp/u-boot/u-boot-hab-status.inc
+++ b/recipes-bsp/u-boot/u-boot-hab-status.inc
@@ -1,0 +1,23 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files/u-boot-hab-status:"
+
+TDX_UBOOT_HAB_STATUS_PATCHES_COMMON = " \
+    file://0001-toradex-common-add-hab-utilities-module.patch \
+"
+
+TDX_UBOOT_HAB_STATUS_PATCHES_HAB = " \
+    ${TDX_UBOOT_HAB_STATUS_PATCHES_COMMON} \
+    file://0001-toradex-adjust-hab_status-exit-code-behavior.patch \
+"
+
+TDX_UBOOT_HAB_STATUS_PATCHES_SECO = " \
+    ${TDX_UBOOT_HAB_STATUS_PATCHES_COMMON} \
+    file://0001-toradex-adjust-ahab_status-exit-code-behavior-seco.patch \
+"
+
+TDX_UBOOT_HAB_STATUS_PATCHES = "${TDX_UBOOT_HAB_STATUS_PATCHES_HAB}"
+TDX_UBOOT_HAB_STATUS_PATCHES:apalis-imx8 = "${TDX_UBOOT_HAB_STATUS_PATCHES_SECO}"
+TDX_UBOOT_HAB_STATUS_PATCHES:colibri-imx8x = "${TDX_UBOOT_HAB_STATUS_PATCHES_SECO}"
+
+SRC_URI:append = " \
+    ${TDX_UBOOT_HAB_STATUS_PATCHES} \
+"

--- a/recipes-bsp/u-boot/u-boot-hab-status.inc
+++ b/recipes-bsp/u-boot/u-boot-hab-status.inc
@@ -14,9 +14,15 @@ TDX_UBOOT_HAB_STATUS_PATCHES_SECO = " \
     file://0001-toradex-adjust-ahab_status-exit-code-behavior-seco.patch \
 "
 
+TDX_UBOOT_HAB_STATUS_PATCHES_ELE = " \
+    ${TDX_UBOOT_HAB_STATUS_PATCHES_COMMON} \
+    file://0001-toradex-adjust-ahab_status-exit-code-behavior-ele.patch \
+"
+
 TDX_UBOOT_HAB_STATUS_PATCHES = "${TDX_UBOOT_HAB_STATUS_PATCHES_HAB}"
 TDX_UBOOT_HAB_STATUS_PATCHES:apalis-imx8 = "${TDX_UBOOT_HAB_STATUS_PATCHES_SECO}"
 TDX_UBOOT_HAB_STATUS_PATCHES:colibri-imx8x = "${TDX_UBOOT_HAB_STATUS_PATCHES_SECO}"
+TDX_UBOOT_HAB_STATUS_PATCHES:mx9-generic-bsp = "${TDX_UBOOT_HAB_STATUS_PATCHES_ELE}"
 
 SRC_URI:append = " \
     ${TDX_UBOOT_HAB_STATUS_PATCHES} \

--- a/recipes-bsp/u-boot/u-boot-hab.inc
+++ b/recipes-bsp/u-boot/u-boot-hab.inc
@@ -238,3 +238,6 @@ do_deploy:append() {
         install -m 0644 ${WORKDIR}/imx-config.fuse ${DEPLOYDIR}
     fi
 }
+
+# HAB/AHAB status command configuration
+require u-boot-hab-status.inc


### PR DESCRIPTION
The U-Boot `hab_status` and `ahab_status` commands print the HAB/AHAB events they find but always return success, so the only way to check the result of the verification from a boot script is to parse their output.

This PR adds patches making both commands return an error whenever an event is reported, on every i.MX SoC family supported by this layer. A well-known RNG self-test event on i.MX6 SoCs is deliberately ignored and does not make the command fail.

Three of the four patches were already carried in `u-boot-fuse.inc` in the `meta-toradex-torizon` layer, which even had a TODO suggesting this move. They are brought here so that the feature is available to every user of this layer and not only to Torizon OS.

The fourth patch is new, and covers a gap. i.MX6, i.MX7 and i.MX8M implement `hab_status` in `arch/arm/mach-imx/hab.c`; i.MX8QM and i.MX8QXP implement `ahab_status` in `arch/arm/mach-imx/imx8/ahab.c` through SECO; and i.MX9x implement it in `arch/arm/mach-imx/ele_ahab.c` through the EdgeLock Enclave. The SECO file is not compiled at all on ELE based SoCs, so they needed their own patch. The right patch set is now selected per machine in the new
`u-boot-hab-status.inc`, which is included from `u-boot-hab.inc`.

Tested on Colibri iMX6, Verdin iMX8MP, Apalis iMX8 and Aquila iMX95. The Aquila iMX95 was verified both with and without ELE events, confirming that `ahab_status` only returns an error when events are present.