### PR TITLE
u-boot: add switch for reproducible K3 bootloader binaries

### DIFF
--- a/classes/include/signed/tdx-signed-k3-secboot.inc
+++ b/classes/include/signed/tdx-signed-k3-secboot.inc
@@ -11,6 +11,11 @@ TDX_K3_SECBOOT_KEY_DIR ?= "${TOPDIR}/keys/ti"
 # variable TDX_K3_SECBOOT_TARGET_HSSE_DEVICE:
 TDX_K3_SUPPRESS_HSSE_WARNINGS ?= "0"
 
+# Whether to generate the bootloader signing certificates reproducibly, so that
+# two builds of the same sources produce byte-identical tiboot3.bin, tispl.bin
+# and u-boot.img; allowed values: 0 or 1.
+TDX_K3_SECBOOT_REPRODUCIBLE ?= "0"
+
 # Choose between HSSE/HSFS variants of tiboot3.bin:
 def target_hsse(d):
     return bb.utils.to_boolean(d.getVar('TDX_K3_SECBOOT_ENABLE')) and \

--- a/docs/README-secure-boot-k3.md
+++ b/docs/README-secure-boot-k3.md
@@ -110,6 +110,7 @@ A few variables can be used to configure its behavior:
 | `TDX_K3_SECBOOT_KEY_DIR` | Location of the keys and certificates that will be used to sign the bootloader images. See the previous session for an example on how to create the keys. | `${TOPDIR}/keys/ti` |
 | `TDX_K3_SECBOOT_TARGET_HSSE_DEVICE` | Whether the build is targeting a HS-FS (`0` (development)) or HS-SE (`1` (production)) device. | `0` |
 | `TDX_K3_SUPPRESS_HSSE_WARNINGS` | Whether to suppress some warning messages about the type of device (HS-FS/HS-SE) that the generated image is targeted. | `0` |
+| `TDX_K3_SECBOOT_REPRODUCIBLE` | Whether to generate the signing certificates reproducibly, so that rebuilding the same sources produces byte-identical bootloader binaries; allowed values: `0` or `1`. | `0` |
 
 **NOTE**: Older versions of this layer provided variables `TDX_K3_HSSE_ENABLE` and `TDX_K3_HSSE_KEY_DIR` which are no longer available. The former has been replaced by `TDX_K3_SECBOOT_ENABLE` along with `TDX_K3_SECBOOT_TARGET_HSSE_DEVICE` and the latter by `TDX_K3_SECBOOT_KEY_DIR`.
 
@@ -128,6 +129,16 @@ The verification chain at boot is then:
 3. The A53 SPL (inside `tispl.bin`) loads `u-boot.img` and likewise asks TIFS to verify the `ti-secure`-wrapped U-Boot payload before jumping into it.
 
 On HS-SE devices, any image that fails verification — or that arrives without a `ti-secure` certificate at all — is rejected and the boot stops.
+
+#### Reproducible bootloader binaries
+
+By default, the signing step embeds a random serial number and a validity period based on the current time in every certificate it generates. Two builds of the same sources therefore produce different `tiboot3.bin`, `tispl.bin` and `u-boot.img`, even though nothing about the images has changed.
+
+Setting `TDX_K3_SECBOOT_REPRODUCIBLE = "1"` makes the certificates deterministic: the serial number is derived from the data being signed, and the validity period runs from `SOURCE_DATE_EPOCH` to the end of 2049. Rebuilding the same sources with the same keys then produces byte-identical bootloader binaries.
+
+The end date is not arbitrary: it is the latest one that X.509 encodes as `UTCTime`, and the boot ROM of the K3 SoCs cannot parse a certificate whose validity is encoded as `GeneralizedTime` - which is what any date from 2050 on requires. A device given such an image **does not boot at all**. Nothing in the boot flow checks whether the certificate has expired, so the date itself carries no meaning; only its encoding does (inferred from [AM6412: TI supports for tiboot3 certificates with validity beyond 2049](https://e2e.ti.com/support/processors-group/processors/f/processors-forum/1491915/am6412-ti-supports-for-tiboot3-certificates-with-validity-beyond-2049)).
+
+This is worth enabling if you re-sign bootloader binaries with your own keys, since it lets you verify a re-signed image by comparing it byte for byte against one produced by the build. It is off by default, so that a build only changes how its certificates are generated when it asks for it.
 
 ### Fusing the keys into the SoC
 

--- a/recipes-bsp/u-boot/files/0001-binman-openssl-Make-generated-certificates-reproduci.patch
+++ b/recipes-bsp/u-boot/files/0001-binman-openssl-Make-generated-certificates-reproduci.patch
@@ -1,0 +1,257 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Tue, 11 Aug 2026 16:55:25 -0300
+Subject: [PATCH] binman: openssl: Make generated certificates reproducible
+
+All four certificate helpers in the openssl bintool run 'openssl req
+-new -x509' without setting a serial number or a validity period, so
+openssl invents both: a random 159-bit serial number, and a validity
+period starting at the current time. Every signature over those fields
+differs accordingly, so two builds of the same source never produce the
+same tiboot3.bin, tispl.bin or u-boot.img on TI K3 platforms.
+
+That defeats the simplest check available to anyone re-signing a boot
+chain with their own keys: sign, then compare byte for byte against the
+original. It also leaves these images out of the reproducible builds
+support described in doc/build/reproducible.rst, even though the FIT
+wrappers around them already honour SOURCE_DATE_EPOCH.
+
+Derive the serial number from the hash of the data being signed, so
+that it is deterministic while remaining distinct for each certificate
+in an image, and keep it to 159 bits so that the encoded certificate
+does not change size. Set the validity period when SOURCE_DATE_EPOCH is
+present, running from that epoch to 20491231235959Z. Nothing which
+consumes these certificates checks the validity period: the ROM and the
+system firmware read the TI extensions carried in the certificate, and
+TI's own shipped firmware certificates have long expired.
+
+That end date is the latest which RFC 5280 section 4.1.2.5 allows to be
+encoded as UTCTime, and is deliberately not the 99991231235959Z which
+the same section offers for a certificate with no well-defined
+expiration date. The K3 boot ROM cannot parse a validity encoded as
+GeneralizedTime, which is what a date in 2050 or later requires, and
+rejects such an image outright: a Verdin AM62 (HS-FS) signed with
+99991231235959Z, or with any 2050 date, does not boot and prints
+nothing at all, while the same image signed with a 2048 or 2049 date
+boots normally. TI reports the same limitation for AM64x [1].
+
+The arguments which set the validity period require OpenSSL 3.4 or
+later, so pass them only when the available openssl is new enough and
+warn otherwise. Such a build keeps a wall-clock validity period and so
+is not reproducible, exactly as it is today. The serial number needs no
+such gate, as -set_serial has always been available.
+
+The four argument lists were byte-identical, which is how one defect
+came to be repeated four times, so factor them into a single place.
+
+[1] https://e2e.ti.com/support/processors-group/processors/f/processors-forum/1491915/am6412-ti-supports-for-tiboot3-certificates-with-validity-beyond-2049
+
+Upstream-Status: Pending
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ tools/binman/btool/openssl.py | 96 ++++++++++++++++++++++++++++++-----
+ tools/binman/ftest.py         | 32 ++++++++++++
+ 2 files changed, 116 insertions(+), 12 deletions(-)
+
+diff --git a/tools/binman/btool/openssl.py b/tools/binman/btool/openssl.py
+index c6df64c5..4ccf1fde 100644
+--- a/tools/binman/btool/openssl.py
++++ b/tools/binman/btool/openssl.py
+@@ -11,9 +11,12 @@ Source code is at https://www.openssl.org/
+ """
+ 
+ import hashlib
++import os
++import time
+ 
+ from binman import bintool
+ from u_boot_pylib import tools
++from u_boot_pylib import tout
+ 
+ 
+ VALID_SHAS = [256, 384, 512, 224]
+@@ -22,6 +25,18 @@ SHA_OIDS = {256:'2.16.840.1.101.3.4.2.1',
+             512:'2.16.840.1.101.3.4.2.3',
+             224:'2.16.840.1.101.3.4.2.4'}
+ 
++# Certificates are given the latest expiration date which RFC 5280 section
++# 4.1.2.5 allows to be encoded as UTCTime. Nothing in the boot flow which
++# consumes these certificates checks the validity period, but the boot ROM of
++# the TI K3 SoCs cannot parse a certificate whose validity is encoded as
++# GeneralizedTime, which is what a date in 2050 or later requires. Such a
++# certificate is rejected and the device does not boot at all, so do not raise
++# this date, however far away it may seem.
++NO_EXPIRY = '20491231235959Z'
++
++# 'openssl req' learned -not_before and -not_after in OpenSSL 3.4
++MIN_VALIDITY_VERSION = (3, 4)
++
+ class Bintoolopenssl(bintool.Bintool):
+     """openssl tool
+ 
+@@ -35,6 +50,71 @@ class Bintoolopenssl(bintool.Bintool):
+         super().__init__(
+             name, 'openssl cryptography toolkit',
+             version_regex=r'OpenSSL (.*) \(', version_args='version')
++        self._version_tuple = None
++
++    def version_tuple(self):
++        """Get the openssl version as a tuple of ints, for comparison
++
++        Returns:
++            tuple of int: (major, minor), or () if the version cannot be parsed
++        """
++        if self._version_tuple is None:
++            # version() returns something like '3.4.1 11 Feb 2025'
++            text = self.version().split()[0]
++            try:
++                self._version_tuple = tuple(
++                    int(part) for part in text.split('.')[:2])
++            except ValueError:
++                self._version_tuple = ()
++        return self._version_tuple
++
++    def _req_args(self, cert_fname, key_fname, config_fname, hashval):
++        """Get the 'openssl req' arguments for creating a certificate
++
++        All of the certificate types below share these arguments. The serial
++        number and the validity period are set explicitly rather than left to
++        openssl, which would otherwise invent a random serial number and a
++        validity period starting at the current time, so that two builds of the
++        same source never produce the same certificate.
++
++        The serial number is derived from the hash of the data being signed, so
++        that it is deterministic while remaining distinct for each certificate
++        in an image.
++
++        The validity period is only set when SOURCE_DATE_EPOCH is present, as
++        described in doc/build/reproducible.rst, and requires an openssl new
++        enough to accept the arguments which set it.
++
++        Args:
++            cert_fname (str): Filename of certificate to create
++            key_fname (str): Filename of .pem file
++            config_fname (str): Filename of the openssl config to use
++            hashval (str): Hash of the data being signed, as a hex string
++
++        Returns:
++            list of str: Arguments to pass to openssl
++        """
++        # Keep the serial number to 159 bits, matching the width and the sign
++        # of the one openssl generates, so that the encoded certificate does
++        # not change size
++        serial = int(hashval[:40], 16) & ((1 << 159) - 1)
++        args = ['req', '-new', '-x509', '-key', key_fname, '-nodes',
++                '-outform', 'DER', '-out', cert_fname, '-config', config_fname,
++                '-sha512', '-set_serial', str(serial)]
++
++        epoch = os.environ.get('SOURCE_DATE_EPOCH')
++        if epoch is not None:
++            if self.version_tuple() >= MIN_VALIDITY_VERSION:
++                not_before = time.strftime('%Y%m%d%H%M%SZ',
++                                           time.gmtime(int(epoch)))
++                args += ['-not_before', not_before, '-not_after', NO_EXPIRY]
++            else:
++                tout.warning(
++                    f"openssl '{self.version()}' cannot set a certificate "
++                    f'validity period, which needs '
++                    f"{'.'.join(str(v) for v in MIN_VALIDITY_VERSION)} or "
++                    f'later; certificates will not be reproducible')
++        return args
+ 
+     def x509_cert(self, cert_fname, input_fname, key_fname, cn, revision,
+                   config_fname):
+@@ -76,9 +156,7 @@ shaType                = OID:2.16.840.1.101.3.4.2.3
+ shaValue               = FORMAT:HEX,OCT:{hashval}
+ imageSize              = INTEGER:{len(indata)}
+ ''', file=outf)
+-        args = ['req', '-new', '-x509', '-key', key_fname, '-nodes',
+-                '-outform', 'DER', '-out', cert_fname, '-config', config_fname,
+-                '-sha512']
++        args = self._req_args(cert_fname, key_fname, config_fname, hashval)
+         return self.run_cmd(*args)
+ 
+     def x509_cert_sysfw(self, cert_fname, input_fname, key_fname, sw_rev,
+@@ -146,9 +224,7 @@ authInPlace = INTEGER:{hex(firewall_cert_data['auth_in_place'])}
+ numFirewallRegions = INTEGER:{firewall_cert_data['num_firewalls']}
+ {firewall_cert_data['certificate']}
+ ''', file=outf)
+-        args = ['req', '-new', '-x509', '-key', key_fname, '-nodes',
+-                '-outform', 'DER', '-out', cert_fname, '-config', config_fname,
+-                '-sha512']
++        args = self._req_args(cert_fname, key_fname, config_fname, hashval)
+         return self.run_cmd(*args)
+ 
+     def x509_cert_rom(self, cert_fname, input_fname, key_fname, sw_rev,
+@@ -227,9 +303,7 @@ emailAddress           = {req_dist_name_dict['emailAddress']}
+  coreDbgEn = INTEGER:0
+  coreDbgSecEn = INTEGER:0
+ ''', file=outf)
+-        args = ['req', '-new', '-x509', '-key', key_fname, '-nodes',
+-                '-outform', 'DER', '-out', cert_fname, '-config', config_fname,
+-                '-sha512']
++        args = self._req_args(cert_fname, key_fname, config_fname, hashval)
+         return self.run_cmd(*args)
+ 
+     def x509_cert_rom_combined(self, cert_fname, input_fname, key_fname, sw_rev,
+@@ -334,9 +408,7 @@ coreDbgSecEn = INTEGER:0
+ 
+ {dm_data_ext_boot_block}
+         ''', file=outf)
+-        args = ['req', '-new', '-x509', '-key', key_fname, '-nodes',
+-                '-outform', 'DER', '-out', cert_fname, '-config', config_fname,
+-                '-sha512']
++        args = self._req_args(cert_fname, key_fname, config_fname, hashval)
+         return self.run_cmd(*args)
+ 
+     def fetch(self, method):
+diff --git a/tools/binman/ftest.py b/tools/binman/ftest.py
+index 8a44bc05..bd61a994 100644
+--- a/tools/binman/ftest.py
++++ b/tools/binman/ftest.py
+@@ -31,6 +31,7 @@ from binman import fmap_util
+ from binman import state
+ from dtoc import fdt
+ from dtoc import fdt_util
++from binman.btool import openssl as openssl_btool
+ from binman.etype import fdtmap
+ from binman.etype import image_header
+ from binman.image import Image
+@@ -7121,6 +7122,37 @@ fdt         fdtmap                Extract the devicetree blob from the fdtmap
+                                 entry_args=entry_args)[0]
+         self.assertGreater(len(data), len(TI_UNSECURE_DATA))
+ 
++    def testPackTiSecureReproducible(self):
++        """Test that TI secured binaries are reproducible
++
++        With SOURCE_DATE_EPOCH set, building the same image twice must produce
++        the same certificate, and therefore the same image. This covers all
++        three of the certificate types which sign a payload.
++        """
++        openssl = bintool.Bintool.create('openssl')
++        if not openssl.is_present():
++            self.skipTest('openssl not available')
++        if openssl.version_tuple() < openssl_btool.MIN_VALIDITY_VERSION:
++            self.skipTest('openssl cannot set a certificate validity period')
++
++        keyfile = self.TestFile('key.key')
++        entry_args = {
++            'keyfile': keyfile,
++        }
++        old_epoch = os.environ.get('SOURCE_DATE_EPOCH')
++        os.environ['SOURCE_DATE_EPOCH'] = '1234567890'
++        try:
++            for dts in ['296_ti_secure.dts', '297_ti_secure_rom.dts',
++                        '298_ti_secure_rom_combined.dts']:
++                first = self._DoReadFileDtb(dts, entry_args=entry_args)[0]
++                second = self._DoReadFileDtb(dts, entry_args=entry_args)[0]
++                self.assertEqual(first, second, f'{dts} is not reproducible')
++        finally:
++            if old_epoch is None:
++                del os.environ['SOURCE_DATE_EPOCH']
++            else:
++                os.environ['SOURCE_DATE_EPOCH'] = old_epoch
++
+     def testEncryptedNoAlgo(self):
+         """Test encrypted node with missing required properties"""
+         with self.assertRaises(ValueError) as e:

--- a/recipes-bsp/u-boot/u-boot-k3-secboot-reproducible.inc
+++ b/recipes-bsp/u-boot/u-boot-k3-secboot-reproducible.inc
@@ -1,0 +1,3 @@
+SRC_URI += "\
+    file://0001-binman-openssl-Make-generated-certificates-reproduci.patch \
+"

--- a/recipes-bsp/u-boot/u-boot-k3-secboot.inc
+++ b/recipes-bsp/u-boot/u-boot-k3-secboot.inc
@@ -15,3 +15,6 @@ do_unpack:append() {
 
 # enable HSM-backed signing for the K3 boot container
 require ${@oe.utils.conditional('TDX_SIGNED_HSM', '1', 'u-boot-k3-secboot-hsm.inc', '', d)}
+
+# enable reproducible certificate generation for the K3 boot container
+require ${@oe.utils.conditional('TDX_K3_SECBOOT_REPRODUCIBLE', '1', 'u-boot-k3-secboot-reproducible.inc', '', d)}


### PR DESCRIPTION
The certificates generated when signing the K3 boot chain carry a random serial number and a validity period taken from the current time, so two builds of the same sources produce different tiboot3.bin, tispl.bin and u-boot.img. That rules out the simplest check available to anyone re-signing those binaries with their own keys: compare the result byte for byte against the one the build produced.

Here we patch binman to make the certificates deterministic (enabled by setting TDX_K3_SECBOOT_REPRODUCIBLE="1"). The variable defaults to 0 so that the change is not a breaking one within the current release branch; it is transitional and is to be removed once the behavior becomes unconditional.

The patch derives the serial number from the data being signed and runs the validity period from SOURCE_DATE_EPOCH to 20491231235959Z.  That end date looks arbitrary but is not: the K3 boot ROM cannot parse a certificate whose validity is encoded as GeneralizedTime, and X.509 requires GeneralizedTime for any date from 2050 on. A Verdin AM62 HS-FS signed with the 99991231235959Z of RFC 5280 section 4.1.2.5, the "no well-defined expiration date" convention, does not boot at all and prints nothing on the console; the same image signed with a 2049 or a 2048 date boots normally. 20491231235959Z is the latest instant expressible as UTCTime and is the workaround TI gives for the same limitation on AM64x [1]. For this reason, the constant carries a comment saying it must not be raised.

[1] https://e2e.ti.com/support/processors-group/processors/f/processors-forum/1491915/am6412-ti-supports-for-tiboot3-certificates-with-validity-beyond-2049

Related-to: TOR-4543