### PR TITLE
Secure debug support for iMX8MP SoMs

### DIFF
--- a/classes/include/secure-debug/tdx-secure-debug-sjc.inc
+++ b/classes/include/secure-debug/tdx-secure-debug-sjc.inc
@@ -3,12 +3,15 @@
 
 # Machines this backend has been validated on.
 TDX_SECURE_DEBUG_SUPPORTED_MACHINES:append = "\
+    toradex-smarc-imx8mp \
     verdin-imx8mm \
+    verdin-imx8mp \
 "
 
 # Fuse map template describing where the SJC fields live on this SoC.
 TDX_SECURE_DEBUG_SJC_FUSE_TEMPLATE ?= ""
 TDX_SECURE_DEBUG_SJC_FUSE_TEMPLATE:mx8mm-generic-bsp = "imx8mm-sjc-template.fuse"
+TDX_SECURE_DEBUG_SJC_FUSE_TEMPLATE:mx8mp-generic-bsp = "imx8mp-sjc-template.fuse"
 
 # Block the HAB software path (HAB_JDE) that can re-enable JTAG from
 # trusted boot software, bypassing the Secure JTAG challenge/response.
@@ -30,7 +33,7 @@ TDX_SECURE_DEBUG_SJC_DISABLE ?= "0"
 # used when TDX_SECURE_DEBUG_MODE = "authenticated".
 #
 # Key length by SoC family:
-#   - i.MX6 / i.MX7 / i.MX8M : 56 bits => 14 hex characters
+#   - i.MX6 / i.MX7 / i.MX8MM : 56 bits => 14 hex characters
 #
 # File format:
 #   - hexadecimal text
@@ -62,6 +65,14 @@ python validate_secure_debug_sjc() {
     # check key file used to answer the secure debug challenge/response mechanism
     if e.data.getVar('TDX_SECURE_DEBUG_MODE') == 'authenticated' and \
             e.data.getVar('TDX_SECURE_DEBUG_SJC_DISABLE') != '1':
+        overrides = (e.data.getVar('MACHINEOVERRIDES') or '').split(':')
+        if 'mx8mp-generic-bsp' in overrides:
+            bb.fatal("Secure debug in authenticated mode is not available on "
+                     "the iMX8MP. NXP defeatured the Secure JTAG mode on this "
+                     "SoC (erratum ERR052318). Set TDX_SECURE_DEBUG_MODE="
+                     "\"no-debug\" or TDX_SECURE_DEBUG_SJC_DISABLE=\"1\" to fully "
+                     "disable JTAG.")
+
         key_file = e.data.getVar('TDX_SECURE_DEBUG_KEY_FILE')
         if not key_file:
             bb.fatal("TDX_SECURE_DEBUG_KEY_FILE must be set when "

--- a/docs/README-secure-debug.md
+++ b/docs/README-secure-debug.md
@@ -8,7 +8,11 @@ To mitigate this risk, this layer provides a feature called **Secure Debug**.
 
 Secure Debug is currently supported on the following SoMs:
 
+- SMARC iMX8MP
 - Verdin iMX8MM
+- Verdin iMX8MP
+
+On the iMX8MP-based SoMs only the non-authenticated modes are available, because NXP defeatured the Secure JTAG mode on that SoC. See [Limitations](#limitations).
 
 Support for additional SoMs and SoC families is planned. Since each SoC family may use a different hardware mechanism to restrict debug access, new platforms may introduce additional variables or different provisioning requirements.
 
@@ -29,6 +33,8 @@ The supported operating modes are:
 - **JTAG Enabled**: JTAG is fully open. This is the default state and is normally used during development.
 - **Secure JTAG**: JTAG access is blocked after reset and can only be reopened by a debugger that knows the programmed response key.
 - **No Debug**: security-sensitive debug features, such as CPU halt and memory access, are disabled. Some lower-risk JTAG features, such as boundary scan, may still remain available depending on the SoC.
+
+Not every SoC of the family supports every mode. On the iMX8MP, "Secure JTAG" is not available and only the "No Debug" operating mode can be used. See [Limitations](#limitations).
 
 In addition to these operating modes, the SJC backend also provides an option to fully disable the JTAG controller. When enabled, all JTAG functionality is disabled, including boundary scan.
 
@@ -189,7 +195,7 @@ Flipping a single bit of the correct key is a useful negative test, because it h
 
 ## Limitations
 
-- Although iMX8MP belongs to the iMX8M family, authenticated Secure Debug is not available on this SoC. NXP states in AN4686 that "the Secure Debug mode is not functional on the i.MX 8M Plus" and references erratum ERR052318. Disabling debug access would still be possible in principle, but this SoC is not currently supported by the layer.
+- Authenticated Secure Debug is not available on the iMX8MP, even though the SoC belongs to the iMX8M family. Erratum ERR052318 states that in Secure JTAG mode the SJC "does not correctly control JTAG access and may not unlock the device for JTAG access", and AN4686 states that "the Secure Debug mode is not functional on the i.MX 8M Plus". NXP defeatured the mode and recommends "No Debug" mode or disabling the SJC instead, which is what the layer offers on this SoC.
 - Only the SJC backend is implemented, and within it only iMX8M is supported. The two-key iMX8/iMX8X variant, the iMX9x EdgeLock Secure Enclave, and TI K3 use different mechanisms and are not supported yet.
 - All devices programmed from the same build share the same response key. See [Key management](#key-management).
 
@@ -198,4 +204,6 @@ Flipping a single bit of the correct key is a useful negative test, because it h
 The implementation was based on the following documents. Access to some of them may be restricted and require a non-disclosure agreement with the SoC vendor.
 
 - AN4686 — *Secure Debug in i.MX 6/7/8M Family of Applications Processors*, Rev. 4.0, 5 February 2025
+- *IMX8MP_1P33A Mask Set Errata*, Rev. 2.1, 2 October 2024
 - *Security Reference Manual for i.MX8M Mini Applications Processor*, Rev. 1, January 2024
+- *Security Reference Manual for i.MX 8M Plus Applications Processor*, Rev. 0, April 2021

--- a/recipes-bsp/imx-fuses/files/README-template.txt
+++ b/recipes-bsp/imx-fuses/files/README-template.txt
@@ -59,7 +59,13 @@ providing the same names with the bank/word/mask values for that SoC's
 fuse map; do not invent new names without also updating the script.
 
 The order of SJC: rows in the file is irrelevant -- the script looks
-them up by name.
+them up by name. Lines that do not start with "SJC:" are ignored, so a
+template may carry "#" comments explaining where its values come from.
+
+A template only needs the rows that the modes supported on its SoC can
+reach. Leaving a row out is a deliberate safety net: create_fuse_cmds.sh
+aborts on a missing entry rather than programming a fuse whose layout it
+cannot know.
 
 As it emits each fuse command, the script also appends the resolved row
 (same format, with <mask> replaced by the value actually programmed) to

--- a/recipes-bsp/imx-fuses/files/imx8mp-sjc-template.fuse
+++ b/recipes-bsp/imx-fuses/files/imx8mp-sjc-template.fuse
@@ -1,0 +1,7 @@
+# Secure JTAG mode is defeatured on this SoC (ERR052318), so the
+# JTAG_SMODE_SECURE and SJC_RESP_* rows are intentionally absent.
+H:T:SJC
+SJC:BOOT_CFG_LOCK_OP:0:0:0x00000008
+SJC:JTAG_SMODE_NODEBUG:1:3:0x00C00000
+SJC:SJC_DISABLE:1:3:0x00200000
+SJC:KTE:1:3:0x00100000

--- a/recipes-bsp/imx-fuses/imx-fuses-native_1.0.bb
+++ b/recipes-bsp/imx-fuses/imx-fuses-native_1.0.bb
@@ -17,6 +17,7 @@ SRC_URI = "\
     file://imx93-template.fuse \
     file://imx95-template.fuse \
     file://imx8mm-sjc-template.fuse \
+    file://imx8mp-sjc-template.fuse \
 "
 
 inherit native


### PR DESCRIPTION
Extends the SJC backend of the secure debug feature to the iMX8M Plus, enabling it on the Verdin iMX8MP and Toradex SMARC iMX8MP.

The iMX8MP cannot offer the authenticated (Secure JTAG) mode. NXP erratum ERR052318 states that in Secure JTAG mode the SJC "does not correctly control JTAG access and may not unlock the device for JTAG access", and AN4686 Rev. 4.0 states that "the Secure Debug mode is not functional on the i.MX 8M Plus".

NXP recommends the "No Debug" mode (`TDX_SECURE_DEBUG_MODE="no-debug"`) or disabling the SJC instead (`TDX_SECURE_DEBUG_SJC_DISABLE="1"`), and that is what this PR offers.

Setting `TDX_SECURE_DEBUG_MODE = "authenticated"` on an iMX8MP fails at parsing time.

Tested on both Verdin iMX8MP and SMARC iMX8MP.